### PR TITLE
Implement constant-related behaviour on a ToyModule class

### DIFF
--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -1,0 +1,28 @@
+class ToyModule
+  def initialize
+    @constant_map = {}
+  end
+
+  def toy_const_get(name)
+    name = name.to_sym
+    raise NameError, "uninitialized constant #{name} for #{self.inspect}" unless constant_map.key?(name)
+
+    constant_map[name]
+  end
+
+  def toy_const_set(name, value)
+    name = name.to_sym
+    raise NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
+    warn "already initialized constant #{name}" if constant_map.key?(name)
+
+    constant_map[name] = value
+  end
+
+  def toy_constants
+    constant_map.keys.map(&:to_sym).sort
+  end
+
+  private
+
+  attr_accessor :constant_map
+end

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+require "toy_module"
+
+[Module, ToyModule].each do |klass|
+
+  describe klass do
+    before do
+      @module = klass.new
+    end
+
+    describe "accessing constants" do
+      specify "reading and writing with a Symbol name" do
+        call_method(:const_set, :FOO, 42)
+
+        assert_equal(42, call_method(:const_get, :FOO))
+      end
+
+      specify "reading and writing with a String name" do
+        call_method(:const_set, "FOO", 42)
+
+        assert_equal(42, call_method(:const_get, "FOO"))
+      end
+
+      specify "raises NameError if constant name doesn't start with capital letter" do
+        assert_raises NameError do
+          call_method(:const_set, "foobar", 42)
+        end
+      end
+
+      specify "raises NameError if name starts with non-alphabetic character" do
+        assert_raises NameError do
+          call_method(:const_set, "_foobar", 42)
+        end
+      end
+
+      specify "raises NameError if constant name contains non-alphabetic character other than underscore" do
+        assert_raises NameError do
+          call_method(:const_set, "FOO!BAR", 42)
+        end
+
+        call_method(:const_set, "FOO_BAR", 42)
+      end
+
+      specify "raises uninitialized constant NameError if unset constant is accessed" do
+        error = assert_raises NameError do
+          call_method(:const_get, "FOO")
+        end
+        assert_match(/uninitialized constant/, error.message)
+      end
+
+      specify "warns when setting a constant that is already set" do
+        call_method(:const_set, "FOO", 42)
+
+        _, err = capture_io do
+          call_method(:const_set, "FOO", 42)
+        end
+
+        assert_match(/already initialized constant/, err)
+      end
+    end
+
+    describe "#constants" do
+      it "returns alphabetized list of constant names coerced to symbols" do
+        call_method(:const_set, :FOO, 42)
+        call_method(:const_set, "BAR", 51)
+  
+        assert_equal [:BAR, :FOO], call_method(:constants)
+      end
+    end
+
+    private
+
+    def call_method(name, *args)
+      name = @module.is_a?(ToyModule) ? "toy_#{name}" : name
+      @module.public_send(name, *args)
+    end
+  end
+end

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -1,70 +1,69 @@
-require "test_helper"
-require "toy_module"
+require 'test_helper'
+require 'toy_module'
 
 [Module, ToyModule].each do |klass|
-
   describe klass do
     before do
       @module = klass.new
     end
 
-    describe "accessing constants" do
-      specify "reading and writing with a Symbol name" do
+    describe 'accessing constants' do
+      specify 'reading and writing with a Symbol name' do
         call_method(:const_set, :FOO, 42)
 
         assert_equal(42, call_method(:const_get, :FOO))
       end
 
-      specify "reading and writing with a String name" do
-        call_method(:const_set, "FOO", 42)
+      specify 'reading and writing with a String name' do
+        call_method(:const_set, 'FOO', 42)
 
-        assert_equal(42, call_method(:const_get, "FOO"))
+        assert_equal(42, call_method(:const_get, 'FOO'))
       end
 
       specify "raises NameError if constant name doesn't start with capital letter" do
         assert_raises NameError do
-          call_method(:const_set, "foobar", 42)
+          call_method(:const_set, 'foobar', 42)
         end
       end
 
-      specify "raises NameError if name starts with non-alphabetic character" do
+      specify 'raises NameError if name starts with non-alphabetic character' do
         assert_raises NameError do
-          call_method(:const_set, "_foobar", 42)
+          call_method(:const_set, '_foobar', 42)
         end
       end
 
-      specify "raises NameError if constant name contains non-alphabetic character other than underscore" do
+      specify 'raises NameError if constant name contains non-alphabetic character other than underscore' do
         assert_raises NameError do
-          call_method(:const_set, "FOO!BAR", 42)
+          call_method(:const_set, 'FOO!BAR', 42)
         end
 
-        call_method(:const_set, "FOO_BAR", 42)
+        call_method(:const_set, 'FOO_BAR', 42)
       end
 
-      specify "raises uninitialized constant NameError if unset constant is accessed" do
+      specify 'raises uninitialized constant NameError if unset constant is accessed' do
         error = assert_raises NameError do
-          call_method(:const_get, "FOO")
+          call_method(:const_get, 'FOO')
         end
         assert_match(/uninitialized constant/, error.message)
       end
 
-      specify "warns when setting a constant that is already set" do
-        call_method(:const_set, "FOO", 42)
+      specify 'warns when setting a constant that is already set' do
+        call_method(:const_set, 'FOO', 42)
 
         _, err = capture_io do
-          call_method(:const_set, "FOO", 42)
+          call_method(:const_set, 'FOO', 42)
         end
 
         assert_match(/already initialized constant/, err)
       end
     end
 
-    describe "#constants" do
-      it "returns alphabetized list of constant names coerced to symbols" do
+    describe '#constants' do
+      it 'returns list of constant names coerced to symbols' do
         call_method(:const_set, :FOO, 42)
-        call_method(:const_set, "BAR", 51)
-  
-        assert_equal [:BAR, :FOO], call_method(:constants)
+        call_method(:const_set, 'BAR', 51)
+
+        assert_equal %i[BAR FOO], call_method(:constants).sort
       end
     end
 


### PR DESCRIPTION
Continuing on with our implementation of a "toy" version of the Ruby object model, this PR introduces a `ToyModule` class with the concept of constants.

To match constant behaviour on [Ruby's `Module`](https://ruby-doc.org/core-2.5.0/Module.html) class, we do the following:
1) Define `toy_const_get` for retrieving the value of a constant
2) Define `toy_const_set` for setting a constant
3) Define `constants` to return the list of constant names as symbols, and alphabetized

with the following specifications:
1) Setting an existing constant should warn
2) Setting a constant should check whether the constant name is valid (starts with upcase, and contains only alphabetic characters and underscores), and raise a NameError otherwise
3) Fetching a non-existent constant should raise a NameError