### PR TITLE
Simple implementation of Module methods

### DIFF
--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -1,6 +1,7 @@
 class ToyModule
   def initialize
     @constant_map = {}
+    @method_map = {}
   end
 
   def toy_const_get(name)
@@ -23,7 +24,16 @@ class ToyModule
     constant_map.keys.map(&:to_sym)
   end
 
+  def toy_define_method(name, method)
+    name = name.to_sym
+    method_map[name] = method
+  end
+
+  def toy_instance_methods
+    method_map.keys.map(&:to_sym)
+  end
+
   private
 
-  attr_accessor :constant_map
+  attr_accessor :constant_map, :method_map
 end

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -67,6 +67,19 @@ require 'toy_module'
       end
     end
 
+    describe '#define_method when passed a proc' do
+      it 'defines instance method on receiver with proc as body' do
+        body = proc { puts 'Hello World!' }
+        call_method(:define_method, :my_method, body)
+
+        assert_equal [:my_method], call_method(:instance_methods)
+      end
+
+      it 'defines instance method with parameters' do
+        skip
+      end
+    end
+
     private
 
     def call_method(name, *args)


### PR DESCRIPTION
Modules have the concept of "methods". From [the documentation](https://ruby-doc.org/core-2.5.0/Module.html),
> A Module is a collection of methods and constants. The methods in a module may be instance methods or module methods. Instance methods appear as methods in a class when the module is included, module methods do not.

Representing methods in our toy implementation of `Module` is tricky because:
1) We don't really have a way to represent a method beyond having some code inside a proc (representing `Method` / `UnboundMethod` are not within scope of this challenge)
2) We don't have a way to call a method yet

As such, we've decided that (within the context of this challenge), a Module having a method means that:
- We can call `toy_define_method` with any Object (we're using `Proc` for now because the true `define_method` can take a Proc) and the method name will be registered
- We can call `toy_instance_methods` on a Module, and we'll receive a list of the instance method names registered on that Module.

@tomstuart -- reading "Instance methods appear as methods in a class when the module is included" in the documentation cleared up a lot of my confusion from earlier about the use of "instance methods" with Modules. 😄 
