### PR TITLE
Challenge 2: Make class hierarchy work in Toyland 🧩

### DIFF
--- a/lib/toy_class.rb
+++ b/lib/toy_class.rb
@@ -8,7 +8,7 @@ class ToyClass < ToyModule
 
   def initialize(toy_superclass)
     @toy_superclass = toy_superclass
-    super
+    super()
   end
 
   def toy_new

--- a/lib/toy_class.rb
+++ b/lib/toy_class.rb
@@ -8,7 +8,7 @@ class ToyClass < ToyModule
   end
 
   def toy_new
-    ToyObject.new
+    ToyObject.new(self)
   end
 
   def toy_superclass

--- a/lib/toy_class.rb
+++ b/lib/toy_class.rb
@@ -3,12 +3,12 @@ require "toy_object"
 
 class ToyClass < ToyModule
   def self.toy_new(toy_superclass = ToyObject)
-    new(toy_superclass)
+    new(self, toy_superclass)
   end
 
-  def initialize(toy_superclass)
+  def initialize(toy_class, toy_superclass)
     @toy_superclass = toy_superclass
-    super()
+    super(toy_class)
   end
 
   def toy_new

--- a/lib/toy_class.rb
+++ b/lib/toy_class.rb
@@ -2,7 +2,11 @@ require "toy_module"
 require "toy_object"
 
 class ToyClass < ToyModule
-  def initialize(toy_superclass = ToyObject)
+  def self.toy_new(toy_superclass = ToyObject)
+    new(toy_superclass)
+  end
+
+  def initialize(toy_superclass)
     @toy_superclass = toy_superclass
     super
   end

--- a/lib/toy_class.rb
+++ b/lib/toy_class.rb
@@ -1,7 +1,17 @@
 require "toy_module"
+require "toy_object"
 
 class ToyClass < ToyModule
+  def initialize(toy_superclass = ToyObject)
+    @toy_superclass = toy_superclass
+    super
+  end
+
   def toy_new
     ToyObject.new
+  end
+
+  def toy_superclass
+    @toy_superclass
   end
 end

--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -1,10 +1,6 @@
 require "toy_object"
 
 class ToyModule < ToyObject
-  def self.toy_new
-    new(self)
-  end
-
   def initialize(toy_class)
     @constant_map = {}
     @method_map = {}

--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -2,13 +2,13 @@ require "toy_object"
 
 class ToyModule < ToyObject
   def self.toy_new
-    new
+    new(self)
   end
 
-  def initialize
+  def initialize(toy_class)
     @constant_map = {}
     @method_map = {}
-    super(self.class)
+    super
   end
 
   def toy_const_get(name)

--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -1,6 +1,10 @@
 require "toy_object"
 
 class ToyModule < ToyObject
+  def self.toy_new
+    new
+  end
+
   def initialize
     @constant_map = {}
     @method_map = {}

--- a/lib/toy_module.rb
+++ b/lib/toy_module.rb
@@ -8,6 +8,7 @@ class ToyModule < ToyObject
   def initialize
     @constant_map = {}
     @method_map = {}
+    super(self.class)
   end
 
   def toy_const_get(name)

--- a/lib/toy_object.rb
+++ b/lib/toy_object.rb
@@ -1,5 +1,9 @@
 class ToyObject
-  def initialize(toy_class = nil)
+  def self.toy_new
+    new(self)
+  end
+
+  def initialize(toy_class)
     @toy_class = toy_class
   end
 

--- a/lib/toy_object.rb
+++ b/lib/toy_object.rb
@@ -1,4 +1,8 @@
 class ToyObject
+  def initialize(toy_class = nil)
+    @toy_class = toy_class
+  end
+
   def toy_instance_variable_get(name)
     ivar_map[name.to_sym]
   end
@@ -17,6 +21,10 @@ class ToyObject
 
   def toy_remove_instance_variable(name)
     ivar_map.delete(name.to_sym)
+  end
+
+  def toy_class
+    @toy_class
   end
 
   private

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -17,13 +17,6 @@ require 'toy_object'
 
     describe "getting a class's superclass" do
       specify 'returns the superclass' do
-        class_a = klass.public_send(@new_method)
-        @class = klass.public_send(@new_method, class_a)
-
-        assert_equal class_a, call_method(:superclass)
-      end
-
-      specify 'uses the correct default superclass' do
         assert_equal object_klass, call_method(:superclass)
       end
     end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -5,7 +5,8 @@ require 'toy_object'
 [[Class, Object], [ToyClass, ToyObject]].each do |klass, object_klass|
   describe klass do
     before do
-      @class = klass.new
+      @new_method = klass == ToyClass ? "toy_new" : "new"
+      @class = klass.public_send(@new_method)
     end
 
     describe 'initializing an object' do
@@ -16,8 +17,8 @@ require 'toy_object'
 
     describe "getting a class's superclass" do
       specify 'returns the superclass' do
-        class_a = klass.new
-        @class = klass.new(class_a)
+        class_a = klass.public_send(@new_method)
+        @class = klass.public_send(@new_method, class_a)
 
         assert_equal class_a, call_method(:superclass)
       end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -14,6 +14,19 @@ require 'toy_object'
       end
     end
 
+    describe "getting a class's superclass" do
+      specify 'returns the superclass' do
+        class_a = klass.new
+        @class = klass.new(class_a)
+
+        assert_equal class_a, call_method(:superclass)
+      end
+
+      specify 'uses the correct default superclass' do
+        assert_equal object_klass, call_method(:superclass)
+      end
+    end
+
     def call_method(name, *args)
       name = @class.is_a?(ToyClass) ? "toy_#{name}" : name
       @class.public_send(name, *args)

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -1,10 +1,11 @@
 require 'test_helper'
+require 'toy_class'
 require 'toy_module'
 
 [Module, ToyModule, Class, ToyClass].each do |klass|
   describe klass do
     before do
-      @new_method = klass == ToyModule ? "toy_new" : "new"
+      @new_method = klass <= ToyModule ? "toy_new" : "new"
       @module = klass.public_send(@new_method)
     end
 

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -4,7 +4,8 @@ require 'toy_module'
 [Module, ToyModule, Class, ToyClass].each do |klass|
   describe klass do
     before do
-      @module = klass.new
+      @new_method = klass == ToyModule ? "toy_new" : "new"
+      @module = klass.public_send(@new_method)
     end
 
     describe 'accessing constants' do

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "toy_class"
 require "toy_object"
 
 # Alternative: we could have created a new class, and delegated the missing
@@ -10,8 +11,11 @@ require "toy_object"
 #   end
 # end
 
-[Object, ToyObject, Module, ToyModule, Class, ToyClass].each do |klass|
-
+[ 
+  [Object, Class], [ToyObject, ToyClass],
+  [Module, Class], [ToyModule, ToyClass],
+  [Class, Class], [ToyClass, ToyClass]
+].each do |klass, class_klass|
   describe klass do
     before do
       @object = klass.new
@@ -70,10 +74,21 @@ require "toy_object"
       it "returns value of instance variable and unsets it" do
         call_method(:instance_variable_set, :@bar, :foo)
         assert call_method(:instance_variable_defined?, :@bar)
-    
+
         assert_equal :foo, call_method(:remove_instance_variable, :@bar)
         assert_nil call_method(:instance_variable_get, :@foo)
         refute call_method(:instance_variable_defined?, :@foo)
+      end
+    end
+
+    describe "getting an instance's class" do
+      specify "returns the class" do
+        my_class = class_klass.new
+        name = my_class.is_a?(ToyClass) ? "toy_new" : "new"
+        my_object = my_class.public_send(name)
+
+        name = my_object.is_a?(ToyObject) ? "toy_class" : "class"
+        assert_equal my_class, my_object.public_send(name)
       end
     end
 

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -18,7 +18,8 @@ require "toy_object"
 ].each do |klass, class_klass|
   describe klass do
     before do
-      @object = klass.new
+      @new_method = klass == ToyObject ? "toy_new" : "new"
+      @object = klass.public_send(@new_method)
     end
 
     describe "accessing instance variables" do
@@ -83,12 +84,16 @@ require "toy_object"
 
     describe "getting an instance's class" do
       specify "returns the class" do
-        my_class = class_klass.new
+        my_class = class_klass.public_send(@new_method)
         name = my_class.is_a?(ToyClass) ? "toy_new" : "new"
         my_object = my_class.public_send(name)
 
         name = my_object.is_a?(ToyObject) ? "toy_class" : "class"
         assert_equal my_class, my_object.public_send(name)
+      end
+
+      specify 'uses the correct default class' do
+        assert_equal klass, call_method(:class)
       end
     end
 

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -84,15 +84,6 @@ require "toy_object"
 
     describe "getting an instance's class" do
       specify "returns the class" do
-        my_class = class_klass.public_send(@new_method)
-        name = my_class.is_a?(ToyClass) ? "toy_new" : "new"
-        my_object = my_class.public_send(name)
-
-        name = my_object.is_a?(ToyObject) ? "toy_class" : "class"
-        assert_equal my_class, my_object.public_send(name)
-      end
-
-      specify 'uses the correct default class' do
         assert_equal klass, call_method(:class)
       end
     end

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -18,7 +18,7 @@ require "toy_object"
 ].each do |klass, class_klass|
   describe klass do
     before do
-      @new_method = klass == ToyObject ? "toy_new" : "new"
+      @new_method = klass <= ToyObject ? "toy_new" : "new"
       @object = klass.public_send(@new_method)
     end
 


### PR DESCRIPTION
In this challenge, we build knowledge of a class hierarchy into our Toy object models:
1) Every object is connected to the class which manufactured it, retrieved with `Object#class`
2) Every class is connected to its superclass, retrieved with `Class#superclass`

Here is an (artfully drawn) diagram of what this looks like, starting with the object `42`:
![PXL_20211028_143414526](https://user-images.githubusercontent.com/22918438/139278815-1d457843-dd9e-4b55-aef4-4039104954df.jpg)

## Summary of changes made
* https://github.com/adrianna-chang-shopify/ruby-object-model/commit/7c0e9706b3e606c1d32ed57e8ec0d275e5a16f45 changes our `ToyClass` initializer to register a `superclass` attribute when instantiating a new class. This superclass defaults to `ToyObject` (because any `Class` that is created without an explicit superclass subclasses `Object`)
* https://github.com/adrianna-chang-shopify/ruby-object-model/commit/c173c71bce0289895e741a270c8f1ba7fc4a885d changes the `ToyObject` initializer to register a `toy_class` attribute. We then alter the _manufacturing_ of new `ToyObject`s in `ToyClass` so what when we create a new object in `ToyClass#toy_new`, we pass along `self` so that `ToyObject` registers the class that manufactured it
* https://github.com/adrianna-chang-shopify/ruby-object-model/commit/4e9103b968f7abff606965a28d383bb4602dec4a is not entirely relevant to the challenge, but a matter of being clearer about the separation of "real" Ruby land vs our Toy implementation of the Ruby object model. We were considering `{ToyObject,ToyModule,ToyClass}.new` a part of our _toy_ API, and referring to it directly in the tests (eg. `@class = ToyClass.new`). The problem then became that we were trying to write constructors (`#initialize`) on our toy objects to do the job of creating a `{ToyObject,ToyModule,ToyClass}`, which goes against the pattern we have of defining Toy APIs with the same names as Ruby, but with `toy_` prepended. To fix this, we defined `self.toy_new` on `{ToyObject,ToyModule,ToyClass}` -- this is now the _public API_ responsible for creating instances of these classes. We _do_ use `#initialize` under the hood still (we have to!), but we consider this "internal" to our toy implementations.
* https://github.com/adrianna-chang-shopify/ruby-object-model/commit/9aedb5afc7b5776f11142d2d68e995ceea1c2cdb fixes the code we wrote to work with the changes merged in [this PR](url), which I forgot to merge in 😅  Nothing too tricky - basically, our initializers need to call `super` so that we get the behaviour for Module and Object in Class, etc... Notably, `ToyModule` needs to call `super` with `self` to correctly register `#class` on created `ToyObjects`. The last change is that, when checking with method to call in our test setup blocks for initialization (ie. `#new` or `#toy_new`), we need to use `<=` rather than checking for direct equality on the class (`==`).