### PR TITLE
Clean up `#call_method` code

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,10 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "minitest/autorun"
+
+module TestHelpers
+  def call_method(receiver, name, *args)
+    name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
+    receiver.public_send(name, *args)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,8 +6,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "minitest/autorun"
 
 module TestHelpers
-  def call_method(receiver, name, *args)
-    name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
-    receiver.public_send(name, *args)
+  def call_method(receiver, meth_prefix, name, *args)
+    receiver.public_send("#{meth_prefix}#{name}", *args)
   end
 end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -7,8 +7,7 @@ require 'toy_object'
     include TestHelpers
 
     before do
-      @new_method = klass == ToyClass ? "toy_new" : "new"
-      @class = klass.public_send(@new_method)
+      @class = call_method(klass, meth_prefix, :new)
     end
 
     describe 'initializing an object' do
@@ -19,7 +18,7 @@ require 'toy_object'
 
     describe "getting a class's superclass" do
       specify 'returns the superclass' do
-        subclass = klass.public_send(@new_method, @class)
+        subclass = call_method(klass, meth_prefix, :new, @class)
         assert_equal @class, call_method(subclass, meth_prefix, :superclass)
       end
 

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -4,6 +4,8 @@ require 'toy_object'
 
 [[Class, Object], [ToyClass, ToyObject]].each do |klass, object_klass|
   describe klass do
+    include TestHelpers
+
     before do
       @new_method = klass == ToyClass ? "toy_new" : "new"
       @class = klass.public_send(@new_method)
@@ -24,11 +26,6 @@ require 'toy_object'
       specify 'uses the correct default superclass' do
         assert_equal object_klass, call_method(@class, :superclass)
       end
-    end
-
-    def call_method(receiver, name, *args)
-      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
-      receiver.public_send(name, *args)
     end
   end
 end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -11,7 +11,7 @@ require 'toy_object'
 
     describe 'initializing an object' do
       specify 'creates a ToyObject instance' do
-        assert_kind_of object_klass, call_method(:new)
+        assert_kind_of object_klass, call_method(@class, :new)
       end
     end
 
@@ -20,17 +20,17 @@ require 'toy_object'
         class_a = klass.public_send(@new_method)
         @class = klass.public_send(@new_method, class_a)
 
-        assert_equal class_a, call_method(:superclass)
+        assert_equal class_a, call_method(@class, :superclass)
       end
 
       specify 'uses the correct default superclass' do
-        assert_equal object_klass, call_method(:superclass)
+        assert_equal object_klass, call_method(@class, :superclass)
       end
     end
 
-    def call_method(name, *args)
-      name = @class.is_a?(ToyClass) ? "toy_#{name}" : name
-      @class.public_send(name, *args)
+    def call_method(receiver, name, *args)
+      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
+      receiver.public_send(name, *args)
     end
   end
 end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'toy_class'
 require 'toy_object'
 
-[[Class, Object], [ToyClass, ToyObject]].each do |klass, object_klass|
+[[Class, Object], [ToyClass, ToyObject, "toy_"]].each do |klass, object_klass, meth_prefix|
   describe klass do
     include TestHelpers
 
@@ -13,18 +13,18 @@ require 'toy_object'
 
     describe 'initializing an object' do
       specify 'creates a ToyObject instance' do
-        assert_kind_of object_klass, call_method(@class, :new)
+        assert_kind_of object_klass, call_method(@class, meth_prefix, :new)
       end
     end
 
     describe "getting a class's superclass" do
       specify 'returns the superclass' do
         subclass = klass.public_send(@new_method, @class)
-        assert_equal @class, call_method(subclass, :superclass)
+        assert_equal @class, call_method(subclass, meth_prefix, :superclass)
       end
 
       specify 'uses the correct default superclass' do
-        assert_equal object_klass, call_method(@class, :superclass)
+        assert_equal object_klass, call_method(@class, meth_prefix, :superclass)
       end
     end
   end

--- a/test/toy_class_test.rb
+++ b/test/toy_class_test.rb
@@ -17,10 +17,8 @@ require 'toy_object'
 
     describe "getting a class's superclass" do
       specify 'returns the superclass' do
-        class_a = klass.public_send(@new_method)
-        @class = klass.public_send(@new_method, class_a)
-
-        assert_equal class_a, call_method(@class, :superclass)
+        subclass = klass.public_send(@new_method, @class)
+        assert_equal @class, call_method(subclass, :superclass)
       end
 
       specify 'uses the correct default superclass' do

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -4,6 +4,8 @@ require 'toy_module'
 
 [Module, ToyModule, Class, ToyClass].each do |klass|
   describe klass do
+    include TestHelpers
+
     before do
       @new_method = klass <= ToyModule ? "toy_new" : "new"
       @module = klass.public_send(@new_method)
@@ -80,13 +82,6 @@ require 'toy_module'
       it 'defines instance method with parameters' do
         skip
       end
-    end
-
-    private
-
-    def call_method(receiver, name, *args)
-      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
-      receiver.public_send(name, *args)
     end
   end
 end

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'toy_class'
 require 'toy_module'
 
-[Module, ToyModule, Class, ToyClass].each do |klass|
+[[Module], [ToyModule, "toy_"], [Class], [ToyClass, "toy_"]].each do |klass, meth_prefix|
   describe klass do
     include TestHelpers
 
@@ -13,49 +13,49 @@ require 'toy_module'
 
     describe 'accessing constants' do
       specify 'reading and writing with a Symbol name' do
-        call_method(@module, :const_set, :FOO, 42)
+        call_method(@module, meth_prefix, :const_set, :FOO, 42)
 
-        assert_equal(42, call_method(@module, :const_get, :FOO))
+        assert_equal(42, call_method(@module, meth_prefix, :const_get, :FOO))
       end
 
       specify 'reading and writing with a String name' do
-        call_method(@module, :const_set, 'FOO', 42)
+        call_method(@module, meth_prefix, :const_set, 'FOO', 42)
 
-        assert_equal(42, call_method(@module, :const_get, 'FOO'))
+        assert_equal(42, call_method(@module, meth_prefix, :const_get, 'FOO'))
       end
 
       specify "raises NameError if constant name doesn't start with capital letter" do
         assert_raises NameError do
-          call_method(@module, :const_set, 'foobar', 42)
+          call_method(@module, meth_prefix, :const_set, 'foobar', 42)
         end
       end
 
       specify 'raises NameError if name starts with non-alphabetic character' do
         assert_raises NameError do
-          call_method(@module, :const_set, '_foobar', 42)
+          call_method(@module, meth_prefix, :const_set, '_foobar', 42)
         end
       end
 
       specify 'raises NameError if constant name contains non-alphabetic character other than underscore' do
         assert_raises NameError do
-          call_method(@module, :const_set, 'FOO!BAR', 42)
+          call_method(@module, meth_prefix, :const_set, 'FOO!BAR', 42)
         end
 
-        call_method(@module, :const_set, 'FOO_BAR', 42)
+        call_method(@module, meth_prefix, :const_set, 'FOO_BAR', 42)
       end
 
       specify 'raises uninitialized constant NameError if unset constant is accessed' do
         error = assert_raises NameError do
-          call_method(@module, :const_get, 'FOO')
+          call_method(@module, meth_prefix, :const_get, 'FOO')
         end
         assert_match(/uninitialized constant/, error.message)
       end
 
       specify 'warns when setting a constant that is already set' do
-        call_method(@module, :const_set, 'FOO', 42)
+        call_method(@module, meth_prefix, :const_set, 'FOO', 42)
 
         _, err = capture_io do
-          call_method(@module, :const_set, 'FOO', 42)
+          call_method(@module, meth_prefix, :const_set, 'FOO', 42)
         end
 
         assert_match(/already initialized constant/, err)
@@ -64,19 +64,19 @@ require 'toy_module'
 
     describe '#constants' do
       it 'returns list of constant names coerced to symbols' do
-        call_method(@module, :const_set, :FOO, 42)
-        call_method(@module, :const_set, 'BAR', 51)
+        call_method(@module, meth_prefix, :const_set, :FOO, 42)
+        call_method(@module, meth_prefix, :const_set, 'BAR', 51)
 
-        assert_equal %i[BAR FOO], call_method(@module, :constants).sort
+        assert_equal %i[BAR FOO], call_method(@module, meth_prefix, :constants).sort
       end
     end
 
     describe '#define_method when passed a proc' do
       it 'defines instance method on receiver with proc as body' do
         body = proc { puts 'Hello World!' }
-        call_method(@module, :define_method, :my_method, body)
+        call_method(@module, meth_prefix, :define_method, :my_method, body)
 
-        assert_includes call_method(@module, :instance_methods), :my_method
+        assert_includes call_method(@module, meth_prefix, :instance_methods), :my_method
       end
 
       it 'defines instance method with parameters' do

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -11,49 +11,49 @@ require 'toy_module'
 
     describe 'accessing constants' do
       specify 'reading and writing with a Symbol name' do
-        call_method(:const_set, :FOO, 42)
+        call_method(@module, :const_set, :FOO, 42)
 
-        assert_equal(42, call_method(:const_get, :FOO))
+        assert_equal(42, call_method(@module, :const_get, :FOO))
       end
 
       specify 'reading and writing with a String name' do
-        call_method(:const_set, 'FOO', 42)
+        call_method(@module, :const_set, 'FOO', 42)
 
-        assert_equal(42, call_method(:const_get, 'FOO'))
+        assert_equal(42, call_method(@module, :const_get, 'FOO'))
       end
 
       specify "raises NameError if constant name doesn't start with capital letter" do
         assert_raises NameError do
-          call_method(:const_set, 'foobar', 42)
+          call_method(@module, :const_set, 'foobar', 42)
         end
       end
 
       specify 'raises NameError if name starts with non-alphabetic character' do
         assert_raises NameError do
-          call_method(:const_set, '_foobar', 42)
+          call_method(@module, :const_set, '_foobar', 42)
         end
       end
 
       specify 'raises NameError if constant name contains non-alphabetic character other than underscore' do
         assert_raises NameError do
-          call_method(:const_set, 'FOO!BAR', 42)
+          call_method(@module, :const_set, 'FOO!BAR', 42)
         end
 
-        call_method(:const_set, 'FOO_BAR', 42)
+        call_method(@module, :const_set, 'FOO_BAR', 42)
       end
 
       specify 'raises uninitialized constant NameError if unset constant is accessed' do
         error = assert_raises NameError do
-          call_method(:const_get, 'FOO')
+          call_method(@module, :const_get, 'FOO')
         end
         assert_match(/uninitialized constant/, error.message)
       end
 
       specify 'warns when setting a constant that is already set' do
-        call_method(:const_set, 'FOO', 42)
+        call_method(@module, :const_set, 'FOO', 42)
 
         _, err = capture_io do
-          call_method(:const_set, 'FOO', 42)
+          call_method(@module, :const_set, 'FOO', 42)
         end
 
         assert_match(/already initialized constant/, err)
@@ -62,19 +62,19 @@ require 'toy_module'
 
     describe '#constants' do
       it 'returns list of constant names coerced to symbols' do
-        call_method(:const_set, :FOO, 42)
-        call_method(:const_set, 'BAR', 51)
+        call_method(@module, :const_set, :FOO, 42)
+        call_method(@module, :const_set, 'BAR', 51)
 
-        assert_equal %i[BAR FOO], call_method(:constants).sort
+        assert_equal %i[BAR FOO], call_method(@module, :constants).sort
       end
     end
 
     describe '#define_method when passed a proc' do
       it 'defines instance method on receiver with proc as body' do
         body = proc { puts 'Hello World!' }
-        call_method(:define_method, :my_method, body)
+        call_method(@module, :define_method, :my_method, body)
 
-        assert_includes call_method(:instance_methods), :my_method
+        assert_includes call_method(@module, :instance_methods), :my_method
       end
 
       it 'defines instance method with parameters' do
@@ -84,9 +84,9 @@ require 'toy_module'
 
     private
 
-    def call_method(name, *args)
-      name = @module.class.name.start_with?("Toy") ? "toy_#{name}" : name
-      @module.public_send(name, *args)
+    def call_method(receiver, name, *args)
+      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
+      receiver.public_send(name, *args)
     end
   end
 end

--- a/test/toy_module_test.rb
+++ b/test/toy_module_test.rb
@@ -7,8 +7,7 @@ require 'toy_module'
     include TestHelpers
 
     before do
-      @new_method = klass <= ToyModule ? "toy_new" : "new"
-      @module = klass.public_send(@new_method)
+      @module = call_method(klass, meth_prefix, :new)
     end
 
     describe 'accessing constants' do

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -20,8 +20,7 @@ require "toy_object"
     include TestHelpers
 
     before do
-      @new_method = klass <= ToyObject ? "toy_new" : "new"
-      @object = klass.public_send(@new_method)
+      @object = call_method(klass, meth_prefix, :new)
     end
 
     describe "accessing instance variables" do

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -24,75 +24,75 @@ require "toy_object"
 
     describe "accessing instance variables" do
       specify "reading and writing with a Symbol name" do
-        call_method(:instance_variable_set, :@foo, :bar)
-        assert_equal :bar, call_method(:instance_variable_get, :@foo)
+        call_method(@object, :instance_variable_set, :@foo, :bar)
+        assert_equal :bar, call_method(@object, :instance_variable_get, :@foo)
 
-        call_method(:instance_variable_set, :@foo, :baz)
-        assert_equal :baz, call_method(:instance_variable_get, :@foo)
+        call_method(@object, :instance_variable_set, :@foo, :baz)
+        assert_equal :baz, call_method(@object, :instance_variable_get, :@foo)
       end
 
       specify "reading and writing with a String name" do
-        call_method(:instance_variable_set, "@foo", :bar)
-        assert_equal :bar, call_method(:instance_variable_get, "@foo")
+        call_method(@object, :instance_variable_set, "@foo", :bar)
+        assert_equal :bar, call_method(@object, :instance_variable_get, "@foo")
       end
 
       specify "reading with a Symbol and writing with a String name" do
-        call_method(:instance_variable_set, "@foo", :bar)
-        assert_equal :bar, call_method(:instance_variable_get, :@foo)
+        call_method(@object, :instance_variable_set, "@foo", :bar)
+        assert_equal :bar, call_method(@object, :instance_variable_get, :@foo)
       end
 
       specify "reading with a String and writing with a Symbol name" do
-        call_method(:instance_variable_set, :@foo, :bar)
-        assert_equal :bar, call_method(:instance_variable_get, "@foo")
+        call_method(@object, :instance_variable_set, :@foo, :bar)
+        assert_equal :bar, call_method(@object, :instance_variable_get, "@foo")
       end
 
       specify "reading an unset instance variable returns nil" do
-        assert_nil call_method(:instance_variable_get, :@foo)
+        assert_nil call_method(@object, :instance_variable_get, :@foo)
       end
     end
 
     describe "#instance_variables" do
       it "returns the names of existing instance variables" do
-        call_method(:instance_variable_set, :@bar, :foo)
-        call_method(:instance_variable_set, :@baz, :foo)
+        call_method(@object, :instance_variable_set, :@bar, :foo)
+        call_method(@object, :instance_variable_set, :@baz, :foo)
 
-        assert_equal [:@bar, :@baz], call_method(:instance_variables)
+        assert_equal [:@bar, :@baz], call_method(@object, :instance_variables)
       end
     end
 
     describe "#instance_variable_defined?" do
       it "returns true if instance variable is set" do
-        call_method(:instance_variable_set, :@bar, :foo)
-        assert call_method(:instance_variable_defined?, :@bar)
+        call_method(@object, :instance_variable_set, :@bar, :foo)
+        assert call_method(@object, :instance_variable_defined?, :@bar)
       end
 
       it "returns false if instance variable is not set" do
-        refute call_method(:instance_variable_defined?, :@bar)
+        refute call_method(@object, :instance_variable_defined?, :@bar)
       end
     end
 
     describe "#remove_instance_variable" do
       it "returns value of instance variable and unsets it" do
-        call_method(:instance_variable_set, :@bar, :foo)
-        assert call_method(:instance_variable_defined?, :@bar)
+        call_method(@object, :instance_variable_set, :@bar, :foo)
+        assert call_method(@object, :instance_variable_defined?, :@bar)
 
-        assert_equal :foo, call_method(:remove_instance_variable, :@bar)
-        assert_nil call_method(:instance_variable_get, :@foo)
-        refute call_method(:instance_variable_defined?, :@foo)
+        assert_equal :foo, call_method(@object, :remove_instance_variable, :@bar)
+        assert_nil call_method(@object, :instance_variable_get, :@foo)
+        refute call_method(@object, :instance_variable_defined?, :@foo)
       end
     end
 
     describe "getting an instance's class" do
       specify "returns the class" do
-        assert_equal klass, call_method(:class)
+        assert_equal klass, call_method(@object, :class)
       end
     end
 
     private
 
-    def call_method(name, *args)
-      name = @object.class.name.start_with?("Toy") ? "toy_#{name}" : name
-      @object.public_send(name, *args)
+    def call_method(receiver, name, *args)
+      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
+      receiver.public_send(name, *args)
     end
   end
 end

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -12,10 +12,10 @@ require "toy_object"
 # end
 
 [ 
-  [Object, Class], [ToyObject, ToyClass],
-  [Module, Class], [ToyModule, ToyClass],
-  [Class, Class], [ToyClass, ToyClass]
-].each do |klass, class_klass|
+  [Object, Class], [ToyObject, ToyClass, "toy_"],
+  [Module, Class], [ToyModule, ToyClass, "toy_"],
+  [Class, Class], [ToyClass, ToyClass, "toy_"]
+].each do |klass, class_klass, meth_prefix|
   describe klass do
     include TestHelpers
 
@@ -26,67 +26,67 @@ require "toy_object"
 
     describe "accessing instance variables" do
       specify "reading and writing with a Symbol name" do
-        call_method(@object, :instance_variable_set, :@foo, :bar)
-        assert_equal :bar, call_method(@object, :instance_variable_get, :@foo)
+        call_method(@object, meth_prefix, :instance_variable_set, :@foo, :bar)
+        assert_equal :bar, call_method(@object, meth_prefix, :instance_variable_get, :@foo)
 
-        call_method(@object, :instance_variable_set, :@foo, :baz)
-        assert_equal :baz, call_method(@object, :instance_variable_get, :@foo)
+        call_method(@object, meth_prefix, :instance_variable_set, :@foo, :baz)
+        assert_equal :baz, call_method(@object, meth_prefix, :instance_variable_get, :@foo)
       end
 
       specify "reading and writing with a String name" do
-        call_method(@object, :instance_variable_set, "@foo", :bar)
-        assert_equal :bar, call_method(@object, :instance_variable_get, "@foo")
+        call_method(@object, meth_prefix, :instance_variable_set, "@foo", :bar)
+        assert_equal :bar, call_method(@object, meth_prefix, :instance_variable_get, "@foo")
       end
 
       specify "reading with a Symbol and writing with a String name" do
-        call_method(@object, :instance_variable_set, "@foo", :bar)
-        assert_equal :bar, call_method(@object, :instance_variable_get, :@foo)
+        call_method(@object, meth_prefix, :instance_variable_set, "@foo", :bar)
+        assert_equal :bar, call_method(@object, meth_prefix, :instance_variable_get, :@foo)
       end
 
       specify "reading with a String and writing with a Symbol name" do
-        call_method(@object, :instance_variable_set, :@foo, :bar)
-        assert_equal :bar, call_method(@object, :instance_variable_get, "@foo")
+        call_method(@object, meth_prefix, :instance_variable_set, :@foo, :bar)
+        assert_equal :bar, call_method(@object, meth_prefix, :instance_variable_get, "@foo")
       end
 
       specify "reading an unset instance variable returns nil" do
-        assert_nil call_method(@object, :instance_variable_get, :@foo)
+        assert_nil call_method(@object, meth_prefix, :instance_variable_get, :@foo)
       end
     end
 
     describe "#instance_variables" do
       it "returns the names of existing instance variables" do
-        call_method(@object, :instance_variable_set, :@bar, :foo)
-        call_method(@object, :instance_variable_set, :@baz, :foo)
+        call_method(@object, meth_prefix, :instance_variable_set, :@bar, :foo)
+        call_method(@object, meth_prefix, :instance_variable_set, :@baz, :foo)
 
-        assert_equal [:@bar, :@baz], call_method(@object, :instance_variables)
+        assert_equal [:@bar, :@baz], call_method(@object, meth_prefix, :instance_variables)
       end
     end
 
     describe "#instance_variable_defined?" do
       it "returns true if instance variable is set" do
-        call_method(@object, :instance_variable_set, :@bar, :foo)
-        assert call_method(@object, :instance_variable_defined?, :@bar)
+        call_method(@object, meth_prefix, :instance_variable_set, :@bar, :foo)
+        assert call_method(@object, meth_prefix, :instance_variable_defined?, :@bar)
       end
 
       it "returns false if instance variable is not set" do
-        refute call_method(@object, :instance_variable_defined?, :@bar)
+        refute call_method(@object, meth_prefix, :instance_variable_defined?, :@bar)
       end
     end
 
     describe "#remove_instance_variable" do
       it "returns value of instance variable and unsets it" do
-        call_method(@object, :instance_variable_set, :@bar, :foo)
-        assert call_method(@object, :instance_variable_defined?, :@bar)
+        call_method(@object, meth_prefix, :instance_variable_set, :@bar, :foo)
+        assert call_method(@object, meth_prefix, :instance_variable_defined?, :@bar)
 
-        assert_equal :foo, call_method(@object, :remove_instance_variable, :@bar)
-        assert_nil call_method(@object, :instance_variable_get, :@foo)
-        refute call_method(@object, :instance_variable_defined?, :@foo)
+        assert_equal :foo, call_method(@object, meth_prefix, :remove_instance_variable, :@bar)
+        assert_nil call_method(@object, meth_prefix, :instance_variable_get, :@foo)
+        refute call_method(@object, meth_prefix, :instance_variable_defined?, :@foo)
       end
     end
 
     describe "getting an instance's class" do
       specify "returns the class" do
-        assert_equal klass, call_method(@object, :class)
+        assert_equal klass, call_method(@object, meth_prefix, :class)
       end
     end
   end

--- a/test/toy_object_test.rb
+++ b/test/toy_object_test.rb
@@ -17,6 +17,8 @@ require "toy_object"
   [Class, Class], [ToyClass, ToyClass]
 ].each do |klass, class_klass|
   describe klass do
+    include TestHelpers
+
     before do
       @new_method = klass <= ToyObject ? "toy_new" : "new"
       @object = klass.public_send(@new_method)
@@ -86,13 +88,6 @@ require "toy_object"
       specify "returns the class" do
         assert_equal klass, call_method(@object, :class)
       end
-    end
-
-    private
-
-    def call_method(receiver, name, *args)
-      name = receiver.class.name.start_with?("Toy") ? "toy_#{name}" : name
-      receiver.public_send(name, *args)
     end
   end
 end


### PR DESCRIPTION
Various refactors to `#call_method` to make things more consistent, reduce repetition, and make it easier to reuse.
We:
- Modify `#call_method`  to take a receiver in https://github.com/adrianna-chang-shopify/ruby-object-model/commit/8833fd5d01fec51f1b5ce07779b1928687cd0b4a
- Refactor one of our tests to use `#call_method` now that we can specify a receiver in https://github.com/adrianna-chang-shopify/ruby-object-model/commit/69c8ac4ceeb1dbdef40708e35847ef89f3ff8d37
- Extract the code out to a module in `test_helper.rb` in https://github.com/adrianna-chang-shopify/ruby-object-model/commit/9b73eebaec2c1c46b404d83889c985d6848bfb50
- Pass in the `toy_` method prefix to `#call_method` to avoid calling `#class` (since `#class` shouldn't really be used in Toyland) in https://github.com/adrianna-chang-shopify/ruby-object-model/commit/e86f21cb21580690d32d672e6f1c2d74c642873f
- Since `#call_method` no longer cares about using `#class`, we can use it for class-level methods in  https://github.com/adrianna-chang-shopify/ruby-object-model/commit/cc416c194f839f73e6920eafe61ed17742c0a982