### PR TITLE
Fix raise / warn for constant getting and setting in Module

### DIFF
--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -39,6 +39,10 @@ module Toy
         ivar_map.delete(name.to_sym)
       end
 
+      def inspect
+        "#<#{self.class}>"
+      end
+
       # Module instance methods
 
       def constant_map
@@ -47,16 +51,16 @@ module Toy
 
       def const_get(name)
         name = name.to_sym
-        raise NameError, "uninitialized constant #{name} for #{inspect}" unless constant_map.key?(name)
+        ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)
 
         constant_map[name]
       end
 
       def const_set(name, value)
         name = name.to_sym
-        raise NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
+        ::Kernel.raise ::NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
 
-        ::Kernel.warn "already initialized constant #{name}" if constant_map.key?(name)
+        ::Kernel.warn "already initialized constant #{inspect}::#{name}" if constant_map.key?(name)
 
         constant_map[name] = value
       end

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -36,24 +36,27 @@ module Toy
         ivar_map.delete(name.to_sym)
       end
 
-      # Module instance methods
+      def inspect
+        "#<#{self.class}>"
+      end
 
+      # Module instance methods
       def constant_map
         @constant_map ||= {}
       end
 
       def const_get(name)
         name = name.to_sym
-        raise NameError, "uninitialized constant #{name} for #{inspect}" unless constant_map.key?(name)
+        ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)
 
         constant_map[name]
       end
 
       def const_set(name, value)
         name = name.to_sym
-        raise NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
+        ::Kernel.raise ::NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
 
-        ::Kernel.warn "already initialized constant #{name}" if constant_map.key?(name)
+        ::Kernel.warn "already initialized constant #{inspect}::#{name}" if constant_map.key?(name)
 
         constant_map[name] = value
       end

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -47,7 +47,7 @@ require "toy/class"
             error = assert_raises NameError do
               @module.const_get("FOO")
             end
-            assert_match(/uninitialized constant/, error.message)
+            assert_match(/uninitialized constant #<#{_Module}(:.*)?>::FOO/, error.message)
           end
 
           specify "warns when setting a constant that is already set" do
@@ -57,7 +57,7 @@ require "toy/class"
               @module.const_set("FOO", 42)
             end
 
-            assert_match(/already initialized constant/, err)
+            assert_match(/already initialized constant #<#{_Module}(:.*)?>::FOO/, err)
           end
         end
 


### PR DESCRIPTION
There were a couple of issues with `#const_get` and `#const_set`, defined on `Toy::Module` and `Toy::Class`. Our tests to assert that an error was raised was sneakily passing because the assertions in our tests were matching a fairly limited regex (just `/uninitialized constant/`).

If we change these assertions to be slightly more specific:
```diff
diff --git a/test/module_test.rb b/test/module_test.rb
index 5cf3524..bfc73e0 100644
--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -47,7 +47,7 @@ require "toy/class"
             error = assert_raises NameError do
               @module.const_get("FOO")
             end
-            assert_match(/uninitialized constant/, error.message)
+            assert_match(/uninitialized constant (.*::)?FOO/, error.message)
           end
 
           specify "warns when setting a constant that is already set" do
```

We see some of failures:
```
  1) Failure:
Module-like behaviour in the Toy namespace::Toy::Class::accessing constants#test_0006_raises uninitialized constant NameError if unset constant is accessed [/Users/adriannachang/src/github.com/Shopify/ruby-object-model/test/module_test.rb:50]:
Expected /uninitialized constant (.*::)?FOO/ to match # encoding: US-ASCII
#    valid: true
"uninitialized constant #<Class:#<BasicObject:0x000000013f1f4588>>::NameError".

  2) Failure:
Module-like behaviour in the Toy namespace::Toy::Module::accessing constants#test_0006_raises uninitialized constant NameError if unset constant is accessed [/Users/adriannachang/src/github.com/Shopify/ruby-object-model/test/module_test.rb:50]:
Expected /uninitialized constant (.*::)?FOO/ to match # encoding: US-ASCII
#    valid: true
"uninitialized constant #<Class:#<BasicObject:0x000000013f20e960>>::NameError".

140 runs, 188 assertions, 2 failures, 0 errors, 0 skips
```

Ultimately, this was failing because the `NameError` constant could not be found, not because we were raising the error we expected. Fully qualifying the `NameError` constant using `::` fixed this issue, but this uncovered a couple more:
- `#raise` was not defined on the instance (needed this to be `Kernel.raise`)
- `#inspect` was not defined on the instance (we define this ourselves to just use `self.class`, ie. `#<CLASS>`, ignoring the fact that real Ruby uses some sort of memory address when denoting `inspect` for an anonymous class)

We also realized that our error message didn't line up quite right with what Ruby gives us (we were using `uninitialized constant CONST for OBJ` when Ruby uses `uninitialized constant OBJ::CONST`), so we modified the error message / warning and made the regexes in the tests more specific.