### PR TITLE
Refactor shared code

### DIFF
--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -56,5 +56,20 @@ module Toy
         constant_map.keys.map(&:to_sym)
       end
     end
+
+    module Methods
+      def method_map
+        @method_map ||= {}
+      end
+
+      def define_method(name, method)
+        name = name.to_sym
+        method_map[name] = method
+      end
+
+      def instance_methods
+        method_map.keys.map(&:to_sym)
+      end
+    end
   end
 end

--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -29,10 +29,6 @@ module Toy
     end
 
     module Constants
-      def inspect
-        "#<#{self.class}>"
-      end
-
       def const_get(name)
         name = name.to_sym
         ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)

--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -25,5 +25,36 @@ module Toy
         ivar_map.delete(name.to_sym)
       end
     end
+
+    module Constants
+      def inspect
+        "#<#{self.class}>"
+      end
+
+      # Module instance methods
+      def constant_map
+        @constant_map ||= {}
+      end
+
+      def const_get(name)
+        name = name.to_sym
+        ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)
+
+        constant_map[name]
+      end
+
+      def const_set(name, value)
+        name = name.to_sym
+        ::Kernel.raise ::NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
+
+        ::Kernel.warn "already initialized constant #{inspect}::#{name}" if constant_map.key?(name)
+
+        constant_map[name] = value
+      end
+
+      def constants
+        constant_map.keys.map(&:to_sym)
+      end
+    end
   end
 end

--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -1,10 +1,6 @@
 module Toy
   module Behaviours
     module InstanceVariables
-      def ivar_map
-        @ivar_map ||= {}
-      end
-
       def instance_variable_get(name)
         ivar_map[name.to_sym]
       end
@@ -24,16 +20,17 @@ module Toy
       def remove_instance_variable(name)
         ivar_map.delete(name.to_sym)
       end
+
+      private
+
+      def ivar_map
+        @ivar_map ||= {}
+      end
     end
 
     module Constants
       def inspect
         "#<#{self.class}>"
-      end
-
-      # Module instance methods
-      def constant_map
-        @constant_map ||= {}
       end
 
       def const_get(name)
@@ -55,13 +52,15 @@ module Toy
       def constants
         constant_map.keys.map(&:to_sym)
       end
+
+      private
+
+      def constant_map
+        @constant_map ||= {}
+      end
     end
 
     module Methods
-      def method_map
-        @method_map ||= {}
-      end
-
       def define_method(name, method)
         name = name.to_sym
         method_map[name] = method
@@ -69,6 +68,12 @@ module Toy
 
       def instance_methods
         method_map.keys.map(&:to_sym)
+      end
+
+      private
+
+      def method_map
+        @method_map ||= {}
       end
     end
   end

--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -1,0 +1,29 @@
+module Toy
+  module Behaviours
+    module InstanceVariables
+      def ivar_map
+        @ivar_map ||= {}
+      end
+
+      def instance_variable_get(name)
+        ivar_map[name.to_sym]
+      end
+
+      def instance_variable_set(name, value)
+        ivar_map[name.to_sym] = value
+      end
+
+      def instance_variables
+        ivar_map.keys
+      end
+
+      def instance_variable_defined?(name)
+        ivar_map.has_key?(name.to_sym)
+      end
+
+      def remove_instance_variable(name)
+        ivar_map.delete(name.to_sym)
+      end
+    end
+  end
+end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -17,35 +17,8 @@ module Toy
       # Object instance methods
       include Behaviours::InstanceVariables
 
-      def inspect
-        "#<#{self.class}>"
-      end
-
       # Module instance methods
-
-      def constant_map
-        @constant_map ||= {}
-      end
-
-      def const_get(name)
-        name = name.to_sym
-        ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)
-
-        constant_map[name]
-      end
-
-      def const_set(name, value)
-        name = name.to_sym
-        ::Kernel.raise ::NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
-
-        ::Kernel.warn "already initialized constant #{inspect}::#{name}" if constant_map.key?(name)
-
-        constant_map[name] = value
-      end
-
-      def constants
-        constant_map.keys.map(&:to_sym)
-      end
+      include Behaviours::Constants
 
       def method_map
         @method_map ||= {}

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -21,6 +21,10 @@ module Toy
       include Behaviours::Constants
       include Behaviours::Methods
 
+      def inspect
+        "#<#{self.class}>"
+      end
+
       # Class instance methods
       def new
         instance = BasicObject.new

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -19,19 +19,7 @@ module Toy
 
       # Module instance methods
       include Behaviours::Constants
-
-      def method_map
-        @method_map ||= {}
-      end
-
-      def define_method(name, method)
-        name = name.to_sym
-        method_map[name] = method
-      end
-
-      def instance_methods
-        method_map.keys.map(&:to_sym)
-      end
+      include Behaviours::Methods
 
       # Class instance methods
       def new

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -1,3 +1,4 @@
+require "toy/behaviours"
 require "toy/object"
 
 module Toy
@@ -14,30 +15,7 @@ module Toy
 
     class << instance
       # Object instance methods
-
-      def ivar_map
-        @ivar_map ||= {}
-      end
-
-      def instance_variable_get(name)
-        ivar_map[name.to_sym]
-      end
-
-      def instance_variable_set(name, value)
-        ivar_map[name.to_sym] = value
-      end
-
-      def instance_variables
-        ivar_map.keys
-      end
-
-      def instance_variable_defined?(name)
-        ivar_map.has_key?(name.to_sym)
-      end
-
-      def remove_instance_variable(name)
-        ivar_map.delete(name.to_sym)
-      end
+      include Behaviours::InstanceVariables
 
       def inspect
         "#<#{self.class}>"
@@ -96,29 +74,7 @@ module Toy
 
         class << instance
           # Object instance methods
-          def ivar_map
-            @ivar_map ||= {}
-          end
-
-          def instance_variable_get(name)
-            ivar_map[name.to_sym]
-          end
-
-          def instance_variable_set(name, value)
-            ivar_map[name.to_sym] = value
-          end
-
-          def instance_variables
-            ivar_map.keys
-          end
-
-          def instance_variable_defined?(name)
-            ivar_map.has_key?(name.to_sym)
-          end
-
-          def remove_instance_variable(name)
-            ivar_map.delete(name.to_sym)
-          end
+          include Behaviours::InstanceVariables
         end      
 
         instance

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -1,3 +1,5 @@
+require "toy/behaviours"
+
 module Toy
   Module = BasicObject.new
 
@@ -11,30 +13,7 @@ module Toy
 
     class << instance
       # Object instance methods
-
-      def ivar_map
-        @ivar_map ||= {}
-      end
-
-      def instance_variable_get(name)
-        ivar_map[name.to_sym]
-      end
-
-      def instance_variable_set(name, value)
-        ivar_map[name.to_sym] = value
-      end
-
-      def instance_variables
-        ivar_map.keys
-      end
-
-      def instance_variable_defined?(name)
-        ivar_map.has_key?(name.to_sym)
-      end
-
-      def remove_instance_variable(name)
-        ivar_map.delete(name.to_sym)
-      end
+      include Behaviours::InstanceVariables
 
       def inspect
         "#<#{self.class}>"

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -15,34 +15,8 @@ module Toy
       # Object instance methods
       include Behaviours::InstanceVariables
 
-      def inspect
-        "#<#{self.class}>"
-      end
-
       # Module instance methods
-      def constant_map
-        @constant_map ||= {}
-      end
-
-      def const_get(name)
-        name = name.to_sym
-        ::Kernel.raise ::NameError, "uninitialized constant #{inspect}::#{name}" unless constant_map.key?(name)
-
-        constant_map[name]
-      end
-
-      def const_set(name, value)
-        name = name.to_sym
-        ::Kernel.raise ::NameError unless name.match?(/^[A-Z][a-zA-Z_]*$/)
-
-        ::Kernel.warn "already initialized constant #{inspect}::#{name}" if constant_map.key?(name)
-
-        constant_map[name] = value
-      end
-
-      def constants
-        constant_map.keys.map(&:to_sym)
-      end
+      include Behaviours::Constants
 
       def method_map
         @method_map ||= {}

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -17,19 +17,7 @@ module Toy
 
       # Module instance methods
       include Behaviours::Constants
-
-      def method_map
-        @method_map ||= {}
-      end
-
-      def define_method(name, method)
-        name = name.to_sym
-        method_map[name] = method
-      end
-
-      def instance_methods
-        method_map.keys.map(&:to_sym)
-      end
+      include Behaviours::Methods
     end
 
     instance

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -18,6 +18,10 @@ module Toy
       # Module instance methods
       include Behaviours::Constants
       include Behaviours::Methods
+
+      def inspect
+        "#<#{self.class}>"
+      end
     end
 
     instance

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -1,3 +1,5 @@
+require "toy/behaviours"
+
 module Toy
   Object = BasicObject.new
 
@@ -34,30 +36,7 @@ module Toy
 
     class << instance
       # Object instance methods
-
-      def ivar_map
-        @ivar_map ||= {}
-      end
-
-      def instance_variable_get(name)
-        ivar_map[name.to_sym]
-      end
-
-      def instance_variable_set(name, value)
-        ivar_map[name.to_sym] = value
-      end
-
-      def instance_variables
-        ivar_map.keys
-      end
-
-      def instance_variable_defined?(name)
-        ivar_map.has_key?(name.to_sym)
-      end
-
-      def remove_instance_variable(name)
-        ivar_map.delete(name.to_sym)
-      end
+      include Behaviours::InstanceVariables
     end
 
     instance

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -37,6 +37,10 @@ module Toy
     class << instance
       # Object instance methods
       include Behaviours::InstanceVariables
+
+      def inspect
+        "#<#{self.class}>"
+      end
     end
 
     instance


### PR DESCRIPTION
Extracts various pieces of shared code into modules. Rather than extract based on the object that implements it (ie. "Module-code", "Class-code"), we extract into modules based on a grouping of behaviour (ie. constants, methods, instance variables, etc.)

I've left the singleton methods untouched for now, as I suspect those will be more difficult to deal with.