### PR TITLE
Fill out remaining portion of Object API

### DIFF
--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -72,5 +72,16 @@ module Toy
         @method_map ||= {}
       end
     end
+
+    module ClassRelationships
+      def kind_of?(klass)
+        superclass = self.class
+        while superclass
+          return true if klass == superclass
+          superclass = superclass.superclass
+        end
+        false
+      end
+    end
   end
 end

--- a/lib/toy/behaviours.rb
+++ b/lib/toy/behaviours.rb
@@ -83,5 +83,15 @@ module Toy
         false
       end
     end
+
+    module Inspection
+      def to_s
+        inspect
+      end
+
+      def inspect
+        "#<#{self.class}>"
+      end
+    end
   end
 end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -53,6 +53,10 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
+        def to_s
+          inspect
+        end
+
         def inspect
           "#<#{self.class}>"
         end
@@ -75,6 +79,14 @@ module Toy
 
             # kind_of?
             include Behaviours::ClassRelationships
+
+            def to_s
+              inspect
+            end
+
+            def inspect
+              "#<#{self.class}>"
+            end
           end
 
           instance

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -4,6 +4,16 @@ require "toy/object"
 module Toy
   Class = BasicObject.new
 
+  # Open up singleton class of Toy::Class
+  class << Class
+    # Object instance methods, because the Class singleton is an object yo!
+    include Behaviours::InstanceVariables
+
+    # Module instance methods, because the Class singleton is a module yo!
+    include Behaviours::Constants
+    include Behaviours::Methods
+  end
+
   def Class.new(superclass = Object)
     instance = BasicObject.new
 

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -12,75 +12,75 @@ module Toy
     # Module instance methods, because the Class singleton is a module yo!
     include Behaviours::Constants
     include Behaviours::Methods
-  end
-
-  def Class.new(superclass = Object)
-    instance = BasicObject.new
-
-    klass = self
-
-    singleton_class = (class << instance; self; end)
-    singleton_class.define_method(:class) { klass }
-    singleton_class.define_method(:superclass) { superclass }
-
-    class << instance
-      # Object instance methods
-      include Behaviours::InstanceVariables
-
-      # Module instance methods
-      include Behaviours::Constants
-      include Behaviours::Methods
-
-      def inspect
-        "#<#{self.class}>"
+  
+    def to_s
+      inspect
+    end
+  
+    def inspect
+      "Toy::Class"
+    end
+  
+    def class
+      Class
+    end
+  
+    def superclass
+      Module
+    end
+  
+    def kind_of?(klass)
+      superclass = self.class
+      while superclass
+        return true if klass == superclass
+        superclass = superclass.superclass
       end
-
-      # Class instance methods
-      def new
-        instance = BasicObject.new
-
-        # self is our anonymous class
-        # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
-        klass = self
-
-        # singleton_class is the singleton class of the instance of the anonymous class
-        singleton_class = (class << instance; self; end)
-        singleton_class.define_method(:class) { klass }
-
-        class << instance
-          # Object instance methods
-          include Behaviours::InstanceVariables
-        end      
-
-        instance
-      end
+      false
     end
 
-    instance
-  end
-
-  def Class.to_s
-    inspect
-  end
-
-  def Class.inspect
-    "Toy::Class"
-  end
-
-  def Class.class
-    Class
-  end
-
-  def Class.superclass
-    Module
-  end
-
-  def Class.kind_of?(klass)
-    superclass = self.class
-    while superclass
-      return true if klass == superclass
-      superclass = superclass.superclass
+    def new(superclass = Object)
+      instance = BasicObject.new
+  
+      klass = self
+  
+      singleton_class = (class << instance; self; end)
+      singleton_class.define_method(:class) { klass }
+      singleton_class.define_method(:superclass) { superclass }
+  
+      class << instance
+        # Object instance methods
+        include Behaviours::InstanceVariables
+  
+        # Module instance methods
+        include Behaviours::Constants
+        include Behaviours::Methods
+  
+        def inspect
+          "#<#{self.class}>"
+        end
+  
+        # Class instance methods
+        def new
+          instance = BasicObject.new
+  
+          # self is our anonymous class
+          # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
+          klass = self
+  
+          # singleton_class is the singleton class of the instance of the anonymous class
+          singleton_class = (class << instance; self; end)
+          singleton_class.define_method(:class) { klass }
+  
+          class << instance
+            # Object instance methods
+            include Behaviours::InstanceVariables
+          end      
+  
+          instance
+        end
+      end
+  
+      instance
     end
-    false
   end
 end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -53,13 +53,8 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
-        def to_s
-          inspect
-        end
-
-        def inspect
-          "#<#{self.class}>"
-        end
+        # to_s and #inspect
+        include Behaviours::Inspection
 
         # Class instance methods
         def new
@@ -80,13 +75,8 @@ module Toy
             # kind_of?
             include Behaviours::ClassRelationships
 
-            def to_s
-              inspect
-            end
-
-            def inspect
-              "#<#{self.class}>"
-            end
+            # to_s and #inspect
+            include Behaviours::Inspection
           end
 
           instance

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -32,7 +32,6 @@ module Toy
       Module
     end
 
-
     def new(superclass = Object)
       instance = BasicObject.new
 

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -12,6 +12,9 @@ module Toy
     # Module instance methods, because the Class singleton is a module yo!
     include Behaviours::Constants
     include Behaviours::Methods
+
+    # kind_of?
+    include Behaviours::ClassRelationships
   
     def to_s
       inspect
@@ -28,15 +31,7 @@ module Toy
     def superclass
       Module
     end
-  
-    def kind_of?(klass)
-      superclass = self.class
-      while superclass
-        return true if klass == superclass
-        superclass = superclass.superclass
-      end
-      false
-    end
+
 
     def new(superclass = Object)
       instance = BasicObject.new

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -15,19 +15,19 @@ module Toy
 
     # kind_of?
     include Behaviours::ClassRelationships
-  
+
     def to_s
       inspect
     end
-  
+
     def inspect
       "Toy::Class"
     end
-  
+
     def class
       Class
     end
-  
+
     def superclass
       Module
     end
@@ -35,21 +35,21 @@ module Toy
 
     def new(superclass = Object)
       instance = BasicObject.new
-  
+
       klass = self
-  
+
       singleton_class = (class << instance; self; end)
       singleton_class.define_method(:class) { klass }
       singleton_class.define_method(:superclass) { superclass }
-  
+
       class << instance
         # Object instance methods
         include Behaviours::InstanceVariables
-  
+
         # Module instance methods
         include Behaviours::Constants
         include Behaviours::Methods
-  
+
         def inspect
           "#<#{self.class}>"
         end
@@ -62,19 +62,19 @@ module Toy
           end
           false
         end
-  
+
         # Class instance methods
         def new
           instance = BasicObject.new
-  
+
           # self is our anonymous class
           # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
           klass = self
-  
+
           # singleton_class is the singleton class of the instance of the anonymous class
           singleton_class = (class << instance; self; end)
           singleton_class.define_method(:class) { klass }
-  
+
           class << instance
             # Object instance methods
             include Behaviours::InstanceVariables
@@ -87,12 +87,12 @@ module Toy
               end
               false
             end
-          end      
-  
+          end
+
           instance
         end
       end
-  
+
       instance
     end
   end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -50,17 +50,11 @@ module Toy
         include Behaviours::Constants
         include Behaviours::Methods
 
+        # kind_of?
+        include Behaviours::ClassRelationships
+
         def inspect
           "#<#{self.class}>"
-        end
-
-        def kind_of?(klass)
-          superclass = self.class
-          while superclass
-            return true if klass == superclass
-            superclass = superclass.superclass
-          end
-          false
         end
 
         # Class instance methods
@@ -79,14 +73,8 @@ module Toy
             # Object instance methods
             include Behaviours::InstanceVariables
 
-            def kind_of?(klass)
-              superclass = self.class
-              while superclass
-                return true if klass == superclass
-                superclass = superclass.superclass
-              end
-              false
-            end
+            # kind_of?
+            include Behaviours::ClassRelationships
           end
 
           instance

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -58,6 +58,15 @@ module Toy
         def inspect
           "#<#{self.class}>"
         end
+
+        def kind_of?(klass)
+          superclass = self.class
+          while superclass
+            return true if klass == superclass
+            superclass = superclass.superclass
+          end
+          false
+        end
   
         # Class instance methods
         def new
@@ -74,6 +83,15 @@ module Toy
           class << instance
             # Object instance methods
             include Behaviours::InstanceVariables
+
+            def kind_of?(klass)
+              superclass = self.class
+              while superclass
+                return true if klass == superclass
+                superclass = superclass.superclass
+              end
+              false
+            end
           end      
   
           instance

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -56,6 +56,15 @@ module Toy
         def inspect
           "#<#{self.class}>"
         end
+
+        def kind_of?(klass)
+          superclass = self.class
+          while superclass
+            return true if klass == superclass
+            superclass = superclass.superclass
+          end
+          false
+        end
       end
   
       instance

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -47,17 +47,11 @@ module Toy
         include Behaviours::Constants
         include Behaviours::Methods
 
+        # kind_of?
+        include Behaviours::ClassRelationships
+
         def inspect
           "#<#{self.class}>"
-        end
-
-        def kind_of?(klass)
-          superclass = self.class
-          while superclass
-            return true if klass == superclass
-            superclass = superclass.superclass
-          end
-          false
         end
       end
 

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -18,35 +18,35 @@ module Toy
     def to_s
       inspect
     end
-  
+
     def inspect
       "Toy::Module"
     end
-  
+
     def class
       Class
     end
-  
+
     def superclass
       Object
     end
 
     def new
       instance = BasicObject.new
-  
+
       klass = self
-  
+
       singleton_class = (class << instance; self; end)
       singleton_class.define_method(:class) { klass }
-  
+
       class << instance
         # Object instance methods
         include Behaviours::InstanceVariables
-  
+
         # Module instance methods
         include Behaviours::Constants
         include Behaviours::Methods
-  
+
         def inspect
           "#<#{self.class}>"
         end
@@ -60,7 +60,7 @@ module Toy
           false
         end
       end
-  
+
       instance
     end
   end

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -12,6 +12,9 @@ module Toy
     include Behaviours::Constants
     include Behaviours::Methods
 
+    # kind_of?
+    include Behaviours::ClassRelationships
+
     def to_s
       inspect
     end
@@ -26,15 +29,6 @@ module Toy
   
     def superclass
       Object
-    end
-  
-    def kind_of?(klass)
-      superclass = self.class
-      while superclass
-        return true if klass == superclass
-        superclass = superclass.superclass
-      end
-      false
     end
 
     def new

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -50,13 +50,8 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
-        def to_s
-          inspect
-        end
-
-        def inspect
-          "#<#{self.class}>"
-        end
+        # to_s and #inspect
+        include Behaviours::Inspection
       end
 
       instance

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -3,6 +3,16 @@ require "toy/behaviours"
 module Toy
   Module = BasicObject.new
 
+    # Open up singleton class of Toy::Module
+    class << Module
+      # Object instance methods, because the Module singleton is an object yo!
+      include Behaviours::InstanceVariables
+  
+      # Module instance methods, because the Module singleton is a module yo!
+      include Behaviours::Constants
+      include Behaviours::Methods
+    end
+
   def Module.new
     instance = BasicObject.new
 

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -50,6 +50,10 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
+        def to_s
+          inspect
+        end
+
         def inspect
           "#<#{self.class}>"
         end

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -3,62 +3,62 @@ require "toy/behaviours"
 module Toy
   Module = BasicObject.new
 
-    # Open up singleton class of Toy::Module
-    class << Module
-      # Object instance methods, because the Module singleton is an object yo!
-      include Behaviours::InstanceVariables
+  # Open up singleton class of Toy::Module
+  class << Module
+    # Object instance methods, because the Module singleton is an object yo!
+    include Behaviours::InstanceVariables
+
+    # Module instance methods, because the Module singleton is a module yo!
+    include Behaviours::Constants
+    include Behaviours::Methods
+
+    def to_s
+      inspect
+    end
   
-      # Module instance methods, because the Module singleton is a module yo!
-      include Behaviours::Constants
-      include Behaviours::Methods
+    def inspect
+      "Toy::Module"
     end
-
-  def Module.new
-    instance = BasicObject.new
-
-    klass = self
-
-    singleton_class = (class << instance; self; end)
-    singleton_class.define_method(:class) { klass }
-
-    class << instance
-      # Object instance methods
-      include Behaviours::InstanceVariables
-
-      # Module instance methods
-      include Behaviours::Constants
-      include Behaviours::Methods
-
-      def inspect
-        "#<#{self.class}>"
+  
+    def class
+      Class
+    end
+  
+    def superclass
+      Object
+    end
+  
+    def kind_of?(klass)
+      superclass = self.class
+      while superclass
+        return true if klass == superclass
+        superclass = superclass.superclass
       end
+      false
     end
 
-    instance
-  end
-
-  def Module.to_s
-    inspect
-  end
-
-  def Module.inspect
-    "Toy::Module"
-  end
-
-  def Module.class
-    Class
-  end
-
-  def Module.superclass
-    Object
-  end
-
-  def Module.kind_of?(klass)
-    superclass = self.class
-    while superclass
-      return true if klass == superclass
-      superclass = superclass.superclass
+    def new
+      instance = BasicObject.new
+  
+      klass = self
+  
+      singleton_class = (class << instance; self; end)
+      singleton_class.define_method(:class) { klass }
+  
+      class << instance
+        # Object instance methods
+        include Behaviours::InstanceVariables
+  
+        # Module instance methods
+        include Behaviours::Constants
+        include Behaviours::Methods
+  
+        def inspect
+          "#<#{self.class}>"
+        end
+      end
+  
+      instance
     end
-    false
   end
 end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -12,6 +12,9 @@ module Toy
     include Behaviours::Constants
     include Behaviours::Methods
 
+    # kind_of?
+    include Behaviours::ClassRelationships
+
     def to_s
       inspect
     end
@@ -26,15 +29,6 @@ module Toy
   
     def class
       Class
-    end
-
-    def kind_of?(klass)
-      superclass = self.class
-      while superclass
-        return true if klass == superclass
-        superclass = superclass.superclass
-      end
-      false
     end
 
     def new

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -52,6 +52,15 @@ module Toy
         def inspect
           "#<#{self.class}>"
         end
+
+        def kind_of?(klass)
+          superclass = self.class
+          while superclass
+            return true if klass == superclass
+            superclass = superclass.superclass
+          end
+          false
+        end
       end
   
       instance

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -3,22 +3,6 @@ require "toy/behaviours"
 module Toy
   Object = BasicObject.new
 
-  def Object.to_s
-    inspect
-  end
-
-  def Object.inspect
-    "Toy::Object"
-  end
-
-  def Object.superclass
-    nil
-  end
-
-  def Object.class
-    Class
-  end
-
   # Open up singleton class of Toy::Object
   class << Object
     # Object instance methods, because the Object singleton is an object yo!
@@ -27,41 +11,50 @@ module Toy
     # Module instance methods, because the Object singleton is a module yo!
     include Behaviours::Constants
     include Behaviours::Methods
-  end
 
-  # Accomplish the same thing with Enumerator.produce!!
-  # 
-  # def Object.kind_of?(klass)
-  #   e = Enumerator.produce(self.class) { |klass| klass.superclass or raise StopIteration }
-  #   e.include?(klass)
-  # end
+    def to_s
+      inspect
+    end
+  
+    def inspect
+      "Toy::Object"
+    end
+  
+    def superclass
+      nil
+    end
+  
+    def class
+      Class
+    end
 
-  def Object.new
-    instance = BasicObject.new
-
-    klass = self
-
-    singleton_class = (class << instance; self; end)
-    singleton_class.define_method(:class) { klass }
-
-    class << instance
-      # Object instance methods
-      include Behaviours::InstanceVariables
-
-      def inspect
-        "#<#{self.class}>"
+    def kind_of?(klass)
+      superclass = self.class
+      while superclass
+        return true if klass == superclass
+        superclass = superclass.superclass
       end
+      false
     end
 
-    instance
-  end
-
-  def Object.kind_of?(klass)
-    superclass = self.class
-    while superclass
-      return true if klass == superclass
-      superclass = superclass.superclass
+    def new
+      instance = BasicObject.new
+  
+      klass = self
+  
+      singleton_class = (class << instance; self; end)
+      singleton_class.define_method(:class) { klass }
+  
+      class << instance
+        # Object instance methods
+        include Behaviours::InstanceVariables
+  
+        def inspect
+          "#<#{self.class}>"
+        end
+      end
+  
+      instance
     end
-    false
   end
 end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -19,6 +19,16 @@ module Toy
     Class
   end
 
+  # Open up singleton class of Toy::Object
+  class << Object
+    # Object instance methods, because the Object singleton is an object yo!
+    include Behaviours::InstanceVariables
+
+    # Module instance methods, because the Object singleton is a module yo!
+    include Behaviours::Constants
+    include Behaviours::Methods
+  end
+
   # Accomplish the same thing with Enumerator.produce!!
   # 
   # def Object.kind_of?(klass)

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -46,6 +46,10 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
+        def to_s
+          inspect
+        end
+
         def inspect
           "#<#{self.class}>"
         end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -43,17 +43,11 @@ module Toy
         # Object instance methods
         include Behaviours::InstanceVariables
 
+        # kind_of?
+        include Behaviours::ClassRelationships
+
         def inspect
           "#<#{self.class}>"
-        end
-
-        def kind_of?(klass)
-          superclass = self.class
-          while superclass
-            return true if klass == superclass
-            superclass = superclass.superclass
-          end
-          false
         end
       end
 

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -46,13 +46,8 @@ module Toy
         # kind_of?
         include Behaviours::ClassRelationships
 
-        def to_s
-          inspect
-        end
-
-        def inspect
-          "#<#{self.class}>"
-        end
+        # to_s and #inspect
+        include Behaviours::Inspection
       end
 
       instance

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -18,31 +18,31 @@ module Toy
     def to_s
       inspect
     end
-  
+
     def inspect
       "Toy::Object"
     end
-  
+
     def superclass
       nil
     end
-  
+
     def class
       Class
     end
 
     def new
       instance = BasicObject.new
-  
+
       klass = self
-  
+
       singleton_class = (class << instance; self; end)
       singleton_class.define_method(:class) { klass }
-  
+
       class << instance
         # Object instance methods
         include Behaviours::InstanceVariables
-  
+
         def inspect
           "#<#{self.class}>"
         end
@@ -56,7 +56,7 @@ module Toy
           false
         end
       end
-  
+
       instance
     end
   end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -76,6 +76,17 @@ require "toy/class"
             assert_equal _Object, @object.class
           end
         end
+
+        describe "#kind_of?" do
+          it "returns true for #{_Object}" do
+            assert @object.kind_of?(_Object)
+          end
+
+          it "returns false for non-#{_Object}" do
+            other_class = ns::Class.new
+            refute @object.kind_of?(other_class)
+          end
+        end
       end
     end
   end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -87,6 +87,18 @@ require "toy/class"
             refute @object.kind_of?(other_class)
           end
         end
+
+        describe "#inspect" do
+          it "inspects the object" do
+            assert_match(/#<#{_Object}(:.*)?>/, @object.inspect)
+          end
+        end
+
+        describe "#to_s" do
+          it "returns Stringified version of the object" do
+            assert_match(/#<#{_Object}(:.*)?>/, @object.to_s)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Closes: https://github.com/adrianna-chang-shopify/ruby-object-model/issues/26

From the issue:
> * the Toy::Object, Toy::Module and Toy::Class classes are missing the fundamental behaviour of objects (bag of instance variables) and modules (bag of constants and method definitions)
> * Toy::Object, Toy::Module and Toy::Class instances are missing some superficial behaviour of objects (#to_s, #inspect, #kind_of)

This PR adds this behaviour to the `Toy::Object` model, extracts relevant bits to modules in our shared `Behaviours` namespace, and adds tests when necessary.

Note that we haven't added tests for the [first commit](https://github.com/adrianna-chang-shopify/ruby-object-model/commit/8219f39ee4572e3cd04c5cf5b0912c734a7704b3) because it was difficult to know how to achieve this without simply duplicating all of the existing object and module tests for the singletons. We tested in IRB to confirm this works 😅  I've added tests for most of the new instance methods (`#kind_of?`, `#to_s`, and `#inspect`), with the caveat that I'm not re-asserting this behaviour in `ClassTest` under the `acts like an object` descriptor. #YOLO #ITHINKWENEEDTOMOVEON 😂 