### PR TITLE
Instances as Ruby classes

### DIFF
--- a/lib/toy.rb
+++ b/lib/toy.rb
@@ -1,0 +1,9 @@
+module Toy
+  autoload(:Behaviours, "toy/behaviours.rb")
+  autoload(:ClassInstance, "toy/class_instance.rb")
+  autoload(:Class, "toy/class.rb")
+  autoload(:ModuleInstance, "toy/module_instance.rb")
+  autoload(:Module, "toy/module.rb")
+  autoload(:ObjectInstance, "toy/object_instance.rb")
+  autoload(:Object, "toy/object.rb")
+end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -1,4 +1,5 @@
 require "toy/behaviours"
+require "toy/module"
 require "toy/object"
 
 module Toy
@@ -33,53 +34,41 @@ module Toy
     end
 
     def new(superclass = Object)
+      ClassInstance.new(self, superclass)
+    end
+  end
+
+  class ClassInstance < ModuleInstance
+    def initialize(klass, superclass)
+      super(klass)
+      @superclass = superclass
+    end
+
+    def superclass
+      @superclass
+    end
+
+    # Class instance methods
+    def new
       instance = BasicObject.new
 
+      # self is our anonymous class
+      # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
       klass = self
 
+      # singleton_class is the singleton class of the instance of the anonymous class
       singleton_class = (class << instance; self; end)
       singleton_class.define_method(:class) { klass }
-      singleton_class.define_method(:superclass) { superclass }
 
       class << instance
         # Object instance methods
         include Behaviours::InstanceVariables
-
-        # Module instance methods
-        include Behaviours::Constants
-        include Behaviours::Methods
 
         # kind_of?
         include Behaviours::ClassRelationships
 
         # to_s and #inspect
         include Behaviours::Inspection
-
-        # Class instance methods
-        def new
-          instance = BasicObject.new
-
-          # self is our anonymous class
-          # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
-          klass = self
-
-          # singleton_class is the singleton class of the instance of the anonymous class
-          singleton_class = (class << instance; self; end)
-          singleton_class.define_method(:class) { klass }
-
-          class << instance
-            # Object instance methods
-            include Behaviours::InstanceVariables
-
-            # kind_of?
-            include Behaviours::ClassRelationships
-
-            # to_s and #inspect
-            include Behaviours::Inspection
-          end
-
-          instance
-        end
       end
 
       instance

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -1,8 +1,3 @@
-require "toy/behaviours"
-require "toy/class_instance"
-require "toy/module"
-require "toy/object"
-
 module Toy
   Class = BasicObject.new
 

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -50,28 +50,7 @@ module Toy
 
     # Class instance methods
     def new
-      instance = BasicObject.new
-
-      # self is our anonymous class
-      # In Ruby, this would look like #<Class:0x00007fae319f3bc0>
-      klass = self
-
-      # singleton_class is the singleton class of the instance of the anonymous class
-      singleton_class = (class << instance; self; end)
-      singleton_class.define_method(:class) { klass }
-
-      class << instance
-        # Object instance methods
-        include Behaviours::InstanceVariables
-
-        # kind_of?
-        include Behaviours::ClassRelationships
-
-        # to_s and #inspect
-        include Behaviours::Inspection
-      end
-
-      instance
+      ObjectInstance.new(self)
     end
   end
 end

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -1,4 +1,5 @@
 require "toy/behaviours"
+require "toy/class_instance"
 require "toy/module"
 require "toy/object"
 
@@ -35,22 +36,6 @@ module Toy
 
     def new(superclass = Object)
       ClassInstance.new(self, superclass)
-    end
-  end
-
-  class ClassInstance < ModuleInstance
-    def initialize(klass, superclass)
-      super(klass)
-      @superclass = superclass
-    end
-
-    def superclass
-      @superclass
-    end
-
-    # Class instance methods
-    def new
-      ObjectInstance.new(self)
     end
   end
 end

--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -1,0 +1,20 @@
+require "toy/module_instance"
+require "toy/object_instance"
+
+module Toy
+  class ClassInstance < ModuleInstance
+    def initialize(klass, superclass)
+      super(klass)
+      @superclass = superclass
+    end
+
+    def superclass
+      @superclass
+    end
+
+    # Class instance methods
+    def new
+      ObjectInstance.new(self)
+    end
+  end
+end

--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -1,6 +1,3 @@
-require "toy/module_instance"
-require "toy/object_instance"
-
 module Toy
   class ClassInstance < ModuleInstance
     def initialize(klass, superclass)

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -1,7 +1,3 @@
-require "toy/behaviours"
-require "toy/module_instance"
-require "toy/object"
-
 module Toy
   Module = BasicObject.new
 

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -1,4 +1,5 @@
 require "toy/behaviours"
+require "toy/module_instance"
 require "toy/object"
 
 module Toy
@@ -35,11 +36,5 @@ module Toy
     def new
       ModuleInstance.new(self)
     end
-  end
-
-  class ModuleInstance < ObjectInstance
-    # Module instance methods
-    include Behaviours::Constants
-    include Behaviours::Methods
   end
 end

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -1,4 +1,5 @@
 require "toy/behaviours"
+require "toy/object"
 
 module Toy
   Module = BasicObject.new
@@ -32,29 +33,13 @@ module Toy
     end
 
     def new
-      instance = BasicObject.new
-
-      klass = self
-
-      singleton_class = (class << instance; self; end)
-      singleton_class.define_method(:class) { klass }
-
-      class << instance
-        # Object instance methods
-        include Behaviours::InstanceVariables
-
-        # Module instance methods
-        include Behaviours::Constants
-        include Behaviours::Methods
-
-        # kind_of?
-        include Behaviours::ClassRelationships
-
-        # to_s and #inspect
-        include Behaviours::Inspection
-      end
-
-      instance
+      ModuleInstance.new(self)
     end
+  end
+
+  class ModuleInstance < ObjectInstance
+    # Module instance methods
+    include Behaviours::Constants
+    include Behaviours::Methods
   end
 end

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -1,0 +1,10 @@
+require "toy/behaviours"
+require "toy/object_instance"
+
+module Toy
+  class ModuleInstance < ObjectInstance
+    # Module instance methods
+    include Behaviours::Constants
+    include Behaviours::Methods
+  end
+end

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -1,6 +1,3 @@
-require "toy/behaviours"
-require "toy/object_instance"
-
 module Toy
   class ModuleInstance < ObjectInstance
     # Module instance methods

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -32,11 +32,11 @@ module Toy
     end
 
     def new
-      Instance.new(self)
+      ObjectInstance.new(self)
     end
   end
 
-  class Instance < BasicObject
+  class ObjectInstance < BasicObject
     # Object instance methods
     include Behaviours::InstanceVariables
 

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -32,25 +32,26 @@ module Toy
     end
 
     def new
-      instance = BasicObject.new
+      Instance.new(self)
+    end
+  end
 
-      klass = self
+  class Instance < BasicObject
+    # Object instance methods
+    include Behaviours::InstanceVariables
 
-      singleton_class = (class << instance; self; end)
-      singleton_class.define_method(:class) { klass }
+    # kind_of?
+    include Behaviours::ClassRelationships
 
-      class << instance
-        # Object instance methods
-        include Behaviours::InstanceVariables
+    # to_s and #inspect
+    include Behaviours::Inspection
 
-        # kind_of?
-        include Behaviours::ClassRelationships
+    def initialize(klass)
+      @klass = klass
+    end
 
-        # to_s and #inspect
-        include Behaviours::Inspection
-      end
-
-      instance
+    def class
+      @klass
     end
   end
 end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -1,6 +1,3 @@
-require "toy/behaviours"
-require "toy/object_instance"
-
 module Toy
   Object = BasicObject.new
 

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -1,4 +1,5 @@
 require "toy/behaviours"
+require "toy/object_instance"
 
 module Toy
   Object = BasicObject.new
@@ -33,25 +34,6 @@ module Toy
 
     def new
       ObjectInstance.new(self)
-    end
-  end
-
-  class ObjectInstance < BasicObject
-    # Object instance methods
-    include Behaviours::InstanceVariables
-
-    # kind_of?
-    include Behaviours::ClassRelationships
-
-    # to_s and #inspect
-    include Behaviours::Inspection
-
-    def initialize(klass)
-      @klass = klass
-    end
-
-    def class
-      @klass
     end
   end
 end

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -1,5 +1,3 @@
-require "toy/behaviours"
-
 module Toy
   class ObjectInstance < BasicObject
     # Object instance methods

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -1,0 +1,22 @@
+require "toy/behaviours"
+
+module Toy
+  class ObjectInstance < BasicObject
+    # Object instance methods
+    include Behaviours::InstanceVariables
+
+    # kind_of?
+    include Behaviours::ClassRelationships
+
+    # to_s and #inspect
+    include Behaviours::Inspection
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def class
+      @klass
+    end
+  end
+end

--- a/test/class_relationships_test.rb
+++ b/test/class_relationships_test.rb
@@ -1,6 +1,3 @@
-require "toy/class"
-require "toy/module"
-require "toy/object"
 require "test_helper"
 
 [

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "toy/class"
 
 [::Object, ::Toy].each do |ns|
   describe "Class-like behaviour in the #{ns} namespace" do
@@ -25,7 +24,7 @@ require "toy/class"
               specify "reading and writing" do
                 @object.instance_variable_set(:@foo, :bar)
                 assert_equal :bar, @object.instance_variable_get(:@foo)
-    
+
                 @object.instance_variable_set(:@foo, :baz)
                 assert_equal :baz, @object.instance_variable_get(:@foo)
               end
@@ -35,7 +34,7 @@ require "toy/class"
               it "returns the names of existing instance variables" do
                 @object.instance_variable_set(:@bar, :foo)
                 @object.instance_variable_set(:@baz, :foo)
-    
+
                 assert_equal [:@bar, :@baz], @object.instance_variables
               end
             end
@@ -55,7 +54,7 @@ require "toy/class"
               it "returns value of instance variable and unsets it" do
                 @object.instance_variable_set(:@bar, :foo)
                 assert @object.instance_variable_defined?(:@bar)
-    
+
                 assert_equal :foo, @object.remove_instance_variable(:@bar)
                 assert_nil @object.instance_variable_get(:@foo)
                 refute @object.instance_variable_defined?(:@foo)

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -1,6 +1,4 @@
 require "test_helper"
-require "toy/module"
-require "toy/class"
 
 [::Object, ::Toy].each do |ns|
   describe "Module-like behaviour in the #{ns} namespace" do

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -1,7 +1,4 @@
 require "test_helper"
-require "toy/object"
-require "toy/module"
-require "toy/class"
 
 [::Object, ::Toy].each do |ns|
   describe "Object-like behaviour in the #{ns} namespace" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,4 +3,6 @@
 # the tests directly with Ruby
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+require "toy"
+
 require "minitest/autorun"


### PR DESCRIPTION
Instead of directly instantiating `BasicObject`s to act as our class instances, then opening the singleton of those `BasicObject`s to define our instance methods and include our shared behaviour modules, we've decided to implement (real Ruby) classes to hold these behaviours.

We now have three classes, each that inherit from `BasicObject`: `ObjectInstance`, `ModuleInstance` and `ClassInstance`. The first two have a constructor that accepts a `klass` argument. While previously we were opening up the instance's singleton and dynamically defining a `#class` method by grabbing `self` (the instance) while it was in scope, we can now just initialize these instances and pass `self` to the constructor. This keeps track of which class manufactured an object - we can now define `#class` to return an ivar set in the constructor.

The last instance class, `ClassInstance`, is a bit special because it also needs to know it's `#superclass`. We accept an additional argument in the constructor to specify this value.