### PR TITLE
Extract test modules

### DIFF
--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -78,10 +78,10 @@ end
       @Class = ns::Class
     end
 
-    [[ns::Class, ns::Object]].each do |singleton, _Object|
+    [ns::Class].each do |singleton|
       describe singleton do
         before do
-          @superclass = _Object
+          @superclass = ns::Object
           @class = singleton.new
         end
 

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -1,7 +1,79 @@
 require "test_helper"
 
+module ClassBehaviourTests
+  def self.included(_)
+    describe "Class-like behaviour" do
+      describe "initializing an object" do
+        before do
+          @object = @class.new
+        end
+
+        specify "creates an instance of the class" do
+          # Ask the instance what its class is; it should be the anonymous
+          # Class stored in @class
+          assert_equal @class, @object.class
+        end
+
+        describe "acts like an object" do
+          describe "accessing instance variables" do
+            specify "reading and writing" do
+              @object.instance_variable_set(:@foo, :bar)
+              assert_equal :bar, @object.instance_variable_get(:@foo)
+
+              @object.instance_variable_set(:@foo, :baz)
+              assert_equal :baz, @object.instance_variable_get(:@foo)
+            end
+          end
+
+          describe "#instance_variables" do
+            it "returns the names of existing instance variables" do
+              @object.instance_variable_set(:@bar, :foo)
+              @object.instance_variable_set(:@baz, :foo)
+
+              assert_equal [:@bar, :@baz], @object.instance_variables
+            end
+          end
+
+          describe "#instance_variable_defined?" do
+            it "returns true if instance variable is set" do
+              @object.instance_variable_set(:@bar, :foo)
+              assert @object.instance_variable_defined?(:@bar)
+            end
+
+            it "returns false if instance variable is not set" do
+              refute @object.instance_variable_defined?(:@bar)
+            end
+          end
+
+          describe "#remove_instance_variable" do
+            it "returns value of instance variable and unsets it" do
+              @object.instance_variable_set(:@bar, :foo)
+              assert @object.instance_variable_defined?(:@bar)
+
+              assert_equal :foo, @object.remove_instance_variable(:@bar)
+              assert_nil @object.instance_variable_get(:@foo)
+              refute @object.instance_variable_defined?(:@foo)
+            end
+          end
+        end
+      end
+
+      describe "getting a class's superclass" do
+        specify "returns the superclass" do
+          assert_equal @superclass, @class.superclass
+        end
+
+        specify "works with custom superclass" do
+          subclass = @Class.new(@class)
+          assert_equal @class, subclass.superclass
+        end
+      end
+    end
+  end
+end
+
 [::Object, ::Toy].each do |ns|
-  describe "Class-like behaviour in the #{ns} namespace" do
+  describe "in the #{ns} namespace" do
     [[ns::Class, ns::Object]].each do |_Class, _Object|
       describe _Class do
         before do
@@ -10,71 +82,7 @@ require "test_helper"
           @class = _Class.new
         end
 
-        describe "initializing an object" do
-          before do
-           @object = @class.new
-          end
-
-          specify "creates an instance of the class" do
-            # Ask the instance what its class is; it should be the anonymous
-            # Class stored in @class
-            assert_equal @class, @object.class
-          end
-
-          describe "acts like an object" do
-            describe "accessing instance variables" do
-              specify "reading and writing" do
-                @object.instance_variable_set(:@foo, :bar)
-                assert_equal :bar, @object.instance_variable_get(:@foo)
-
-                @object.instance_variable_set(:@foo, :baz)
-                assert_equal :baz, @object.instance_variable_get(:@foo)
-              end
-            end
-
-            describe "#instance_variables" do
-              it "returns the names of existing instance variables" do
-                @object.instance_variable_set(:@bar, :foo)
-                @object.instance_variable_set(:@baz, :foo)
-
-                assert_equal [:@bar, :@baz], @object.instance_variables
-              end
-            end
-
-            describe "#instance_variable_defined?" do
-              it "returns true if instance variable is set" do
-                @object.instance_variable_set(:@bar, :foo)
-                assert @object.instance_variable_defined?(:@bar)
-              end
-
-              it "returns false if instance variable is not set" do
-                refute @object.instance_variable_defined?(:@bar)
-              end
-            end
-
-            describe "#remove_instance_variable" do
-              it "returns value of instance variable and unsets it" do
-                @object.instance_variable_set(:@bar, :foo)
-                assert @object.instance_variable_defined?(:@bar)
-
-                assert_equal :foo, @object.remove_instance_variable(:@bar)
-                assert_nil @object.instance_variable_get(:@foo)
-                refute @object.instance_variable_defined?(:@foo)
-              end
-            end
-          end
-        end
-
-        describe "getting a class's superclass" do
-          specify "returns the superclass" do
-            assert_equal @superclass, @class.superclass
-          end
-
-          specify "works with custom superclass" do
-            subclass = @Class.new(@class)
-            assert_equal @class, subclass.superclass
-          end
-        end
+        include ClassBehaviourTests
       end
     end
   end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
     [[ns::Class, ns::Object]].each do |_Class, _Object|
       describe _Class do
         before do
+          @Class = ns::Class
+          @superclass = _Object
           @class = _Class.new
         end
 
@@ -65,11 +67,11 @@ require "test_helper"
 
         describe "getting a class's superclass" do
           specify "returns the superclass" do
-            assert_equal _Object, @class.superclass
+            assert_equal @superclass, @class.superclass
           end
 
           specify "works with custom superclass" do
-            subclass = _Class.new(@class)
+            subclass = @Class.new(@class)
             assert_equal @class, subclass.superclass
           end
         end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -74,10 +74,13 @@ end
 
 [::Object, ::Toy].each do |ns|
   describe "in the #{ns} namespace" do
+    before do
+      @Class = ns::Class
+    end
+
     [[ns::Class, ns::Object]].each do |singleton, _Object|
       describe singleton do
         before do
-          @Class = ns::Class
           @superclass = _Object
           @class = singleton.new
         end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -74,12 +74,12 @@ end
 
 [::Object, ::Toy].each do |ns|
   describe "in the #{ns} namespace" do
-    [[ns::Class, ns::Object]].each do |_Class, _Object|
-      describe _Class do
+    [[ns::Class, ns::Object]].each do |singleton, _Object|
+      describe singleton do
         before do
           @Class = ns::Class
           @superclass = _Object
-          @class = _Class.new
+          @class = singleton.new
         end
 
         include ClassBehaviourTests

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -77,11 +77,11 @@ end
 
 [::Object, ::Toy].each do |ns|
   describe "in the #{ns} namespace" do
-    [ns::Module, ns::Class].each do |_Module|
-      describe _Module do
+    [ns::Module, ns::Class].each do |singleton|
+      describe singleton do
         before do
-          @class = _Module
-          @module = _Module.new
+          @class = singleton
+          @module = singleton.new
         end
 
         include ModuleBehaviourTests

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -1,7 +1,82 @@
 require "test_helper"
 
+module ModuleBehaviourTests
+  def self.included(_)
+    describe "Module-like behaviour" do
+      describe "accessing constants" do
+        specify "reading and writing with a Symbol name" do
+          @module.const_set(:FOO, 42)
+
+          assert_equal(42, @module.const_get(:FOO))
+        end
+
+        specify "reading and writing with a String name" do
+          @module.const_set("FOO", 42)
+
+          assert_equal(42, @module.const_get("FOO"))
+        end
+
+        specify "raises NameError if constant name doesn't start with capital letter" do
+          assert_raises NameError do
+            @module.const_set("foobar", 42)
+          end
+        end
+
+        specify "raises NameError if name starts with non-alphabetic character" do
+          assert_raises NameError do
+            @module.const_set("_foobar", 42)
+          end
+        end
+
+        specify "raises NameError if constant name contains non-alphabetic character other than underscore" do
+          assert_raises NameError do
+            @module.const_set("FOO!BAR", 42)
+          end
+
+          @module.const_set("FOO_BAR", 42)
+        end
+
+        specify "raises uninitialized constant NameError if unset constant is accessed" do
+          error = assert_raises NameError do
+            @module.const_get("FOO")
+          end
+          assert_match(/uninitialized constant #<#{@class}(:.*)?>::FOO/, error.message)
+        end
+
+        specify "warns when setting a constant that is already set" do
+          @module.const_set("FOO", 42)
+
+          _, err = capture_io do
+            @module.const_set("FOO", 42)
+          end
+
+          assert_match(/already initialized constant #<#{@class}(:.*)?>::FOO/, err)
+        end
+      end
+
+      describe "#constants" do
+        it "returns list of constant names coerced to symbols" do
+          @module.const_set(:FOO, 42)
+          @module.const_set("BAR", 51)
+
+          assert_equal %i[BAR FOO], @module.constants.sort
+        end
+      end
+
+      describe "#define_method when passed a proc" do
+        it "defines instance method on receiver with proc as body" do
+          body = proc { puts "Hello World!" }
+          @module.define_method(:my_method, body)
+
+          assert_includes @module.instance_methods, :my_method
+        end
+      end
+    end
+  end
+end
+
 [::Object, ::Toy].each do |ns|
-  describe "Module-like behaviour in the #{ns} namespace" do
+  describe "in the #{ns} namespace" do
     [ns::Module, ns::Class].each do |_Module|
       describe _Module do
         before do
@@ -9,74 +84,7 @@ require "test_helper"
           @module = _Module.new
         end
 
-        describe "accessing constants" do
-          specify "reading and writing with a Symbol name" do
-            @module.const_set(:FOO, 42)
-
-            assert_equal(42, @module.const_get(:FOO))
-          end
-
-          specify "reading and writing with a String name" do
-            @module.const_set("FOO", 42)
-
-            assert_equal(42, @module.const_get("FOO"))
-          end
-
-          specify "raises NameError if constant name doesn't start with capital letter" do
-            assert_raises NameError do
-              @module.const_set("foobar", 42)
-            end
-          end
-
-          specify "raises NameError if name starts with non-alphabetic character" do
-            assert_raises NameError do
-              @module.const_set("_foobar", 42)
-            end
-          end
-
-          specify "raises NameError if constant name contains non-alphabetic character other than underscore" do
-            assert_raises NameError do
-              @module.const_set("FOO!BAR", 42)
-            end
-
-            @module.const_set("FOO_BAR", 42)
-          end
-
-          specify "raises uninitialized constant NameError if unset constant is accessed" do
-            error = assert_raises NameError do
-              @module.const_get("FOO")
-            end
-            assert_match(/uninitialized constant #<#{@class}(:.*)?>::FOO/, error.message)
-          end
-
-          specify "warns when setting a constant that is already set" do
-            @module.const_set("FOO", 42)
-
-            _, err = capture_io do
-              @module.const_set("FOO", 42)
-            end
-
-            assert_match(/already initialized constant #<#{@class}(:.*)?>::FOO/, err)
-          end
-        end
-
-        describe "#constants" do
-          it "returns list of constant names coerced to symbols" do
-            @module.const_set(:FOO, 42)
-            @module.const_set("BAR", 51)
-
-            assert_equal %i[BAR FOO], @module.constants.sort
-          end
-        end
-
-        describe "#define_method when passed a proc" do
-          it "defines instance method on receiver with proc as body" do
-            body = proc { puts "Hello World!" }
-            @module.define_method(:my_method, body)
-
-            assert_includes @module.instance_methods, :my_method
-          end
-        end
+        include ModuleBehaviourTests
       end
     end
   end

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
     [ns::Module, ns::Class].each do |_Module|
       describe _Module do
         before do
+          @class = _Module
           @module = _Module.new
         end
 
@@ -45,7 +46,7 @@ require "test_helper"
             error = assert_raises NameError do
               @module.const_get("FOO")
             end
-            assert_match(/uninitialized constant #<#{_Module}(:.*)?>::FOO/, error.message)
+            assert_match(/uninitialized constant #<#{@class}(:.*)?>::FOO/, error.message)
           end
 
           specify "warns when setting a constant that is already set" do
@@ -55,7 +56,7 @@ require "test_helper"
               @module.const_set("FOO", 42)
             end
 
-            assert_match(/already initialized constant #<#{_Module}(:.*)?>::FOO/, err)
+            assert_match(/already initialized constant #<#{@class}(:.*)?>::FOO/, err)
           end
         end
 

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
     [ns::Object, ns::Module, ns::Class].each do |_Object|
       describe _Object do
         before do
+          @Class = ns::Class
+          @class = _Object
           @object = _Object.new
         end
 
@@ -70,30 +72,30 @@ require "test_helper"
 
         describe "getting an instance's class" do
           specify "returns the class" do
-            assert_equal _Object, @object.class
+            assert_equal @class, @object.class
           end
         end
 
         describe "#kind_of?" do
-          it "returns true for #{_Object}" do
-            assert @object.kind_of?(_Object)
+          it "returns true for #{@class}" do
+            assert @object.kind_of?(@class)
           end
 
-          it "returns false for non-#{_Object}" do
-            other_class = ns::Class.new
+          it "returns false for non-#{@class}" do
+            other_class = @Class.new
             refute @object.kind_of?(other_class)
           end
         end
 
         describe "#inspect" do
           it "inspects the object" do
-            assert_match(/#<#{_Object}(:.*)?>/, @object.inspect)
+            assert_match(/#<#{@class}(:.*)?>/, @object.inspect)
           end
         end
 
         describe "#to_s" do
           it "returns Stringified version of the object" do
-            assert_match(/#<#{_Object}(:.*)?>/, @object.to_s)
+            assert_match(/#<#{@class}(:.*)?>/, @object.to_s)
           end
         end
       end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -97,10 +97,13 @@ end
 
 [::Object, ::Toy].each do |ns|
   describe "in the #{ns} namespace" do
+    before do
+      @Class = ns::Class
+    end
+
     [ns::Object, ns::Module, ns::Class].each do |singleton|
       describe singleton do
         before do
-          @Class = ns::Class
           @class = singleton
           @object = singleton.new
         end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -97,12 +97,12 @@ end
 
 [::Object, ::Toy].each do |ns|
   describe "in the #{ns} namespace" do
-    [ns::Object, ns::Module, ns::Class].each do |_Object|
-      describe _Object do
+    [ns::Object, ns::Module, ns::Class].each do |singleton|
+      describe singleton do
         before do
           @Class = ns::Class
-          @class = _Object
-          @object = _Object.new
+          @class = singleton
+          @object = singleton.new
         end
 
         include ObjectBehaviourTests

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -1,7 +1,102 @@
 require "test_helper"
 
+module ObjectBehaviourTests
+  def self.included(_)
+    describe "Object-like behaviour" do
+      describe "accessing instance variables" do
+        specify "reading and writing with a Symbol name" do
+          @object.instance_variable_set(:@foo, :bar)
+          assert_equal :bar, @object.instance_variable_get(:@foo)
+
+          @object.instance_variable_set(:@foo, :baz)
+          assert_equal :baz, @object.instance_variable_get(:@foo)
+        end
+
+        specify "reading and writing with a String name" do
+          @object.instance_variable_set("@foo", :bar)
+          assert_equal :bar, @object.instance_variable_get("@foo")
+        end
+
+        specify "reading with a Symbol and writing with a String name" do
+          @object.instance_variable_set("@foo", :bar)
+          assert_equal :bar, @object.instance_variable_get(:@foo)
+        end
+
+        specify "reading with a String and writing with a Symbol name" do
+          @object.instance_variable_set(:@foo, :bar)
+          assert_equal :bar, @object.instance_variable_get("@foo")
+        end
+
+        specify "reading an unset instance variable returns nil" do
+          assert_nil @object.instance_variable_get(:@foo)
+        end
+      end
+
+      describe "#instance_variables" do
+        it "returns the names of existing instance variables" do
+          @object.instance_variable_set(:@bar, :foo)
+          @object.instance_variable_set(:@baz, :foo)
+
+          assert_equal [:@bar, :@baz], @object.instance_variables
+        end
+      end
+
+      describe "#instance_variable_defined?" do
+        it "returns true if instance variable is set" do
+          @object.instance_variable_set(:@bar, :foo)
+          assert @object.instance_variable_defined?(:@bar)
+        end
+
+        it "returns false if instance variable is not set" do
+          refute @object.instance_variable_defined?(:@bar)
+        end
+      end
+
+      describe "#remove_instance_variable" do
+        it "returns value of instance variable and unsets it" do
+          @object.instance_variable_set(:@bar, :foo)
+          assert @object.instance_variable_defined?(:@bar)
+
+          assert_equal :foo, @object.remove_instance_variable(:@bar)
+          assert_nil @object.instance_variable_get(:@foo)
+          refute @object.instance_variable_defined?(:@foo)
+        end
+      end
+
+      describe "getting an instance's class" do
+        specify "returns the class" do
+          assert_equal @class, @object.class
+        end
+      end
+
+      describe "#kind_of?" do
+        it "returns true for #{@class}" do
+          assert @object.kind_of?(@class)
+        end
+
+        it "returns false for non-#{@class}" do
+          other_class = @Class.new
+          refute @object.kind_of?(other_class)
+        end
+      end
+
+      describe "#inspect" do
+        it "inspects the object" do
+          assert_match(/#<#{@class}(:.*)?>/, @object.inspect)
+        end
+      end
+
+      describe "#to_s" do
+        it "returns Stringified version of the object" do
+          assert_match(/#<#{@class}(:.*)?>/, @object.to_s)
+        end
+      end
+    end
+  end
+end
+
 [::Object, ::Toy].each do |ns|
-  describe "Object-like behaviour in the #{ns} namespace" do
+  describe "in the #{ns} namespace" do
     [ns::Object, ns::Module, ns::Class].each do |_Object|
       describe _Object do
         before do
@@ -10,94 +105,7 @@ require "test_helper"
           @object = _Object.new
         end
 
-        describe "accessing instance variables" do
-          specify "reading and writing with a Symbol name" do
-            @object.instance_variable_set(:@foo, :bar)
-            assert_equal :bar, @object.instance_variable_get(:@foo)
-
-            @object.instance_variable_set(:@foo, :baz)
-            assert_equal :baz, @object.instance_variable_get(:@foo)
-          end
-
-          specify "reading and writing with a String name" do
-            @object.instance_variable_set("@foo", :bar)
-            assert_equal :bar, @object.instance_variable_get("@foo")
-          end
-
-          specify "reading with a Symbol and writing with a String name" do
-            @object.instance_variable_set("@foo", :bar)
-            assert_equal :bar, @object.instance_variable_get(:@foo)
-          end
-
-          specify "reading with a String and writing with a Symbol name" do
-            @object.instance_variable_set(:@foo, :bar)
-            assert_equal :bar, @object.instance_variable_get("@foo")
-          end
-
-          specify "reading an unset instance variable returns nil" do
-            assert_nil @object.instance_variable_get(:@foo)
-          end
-        end
-
-        describe "#instance_variables" do
-          it "returns the names of existing instance variables" do
-            @object.instance_variable_set(:@bar, :foo)
-            @object.instance_variable_set(:@baz, :foo)
-
-            assert_equal [:@bar, :@baz], @object.instance_variables
-          end
-        end
-
-        describe "#instance_variable_defined?" do
-          it "returns true if instance variable is set" do
-            @object.instance_variable_set(:@bar, :foo)
-            assert @object.instance_variable_defined?(:@bar)
-          end
-
-          it "returns false if instance variable is not set" do
-            refute @object.instance_variable_defined?(:@bar)
-          end
-        end
-
-        describe "#remove_instance_variable" do
-          it "returns value of instance variable and unsets it" do
-            @object.instance_variable_set(:@bar, :foo)
-            assert @object.instance_variable_defined?(:@bar)
-
-            assert_equal :foo, @object.remove_instance_variable(:@bar)
-            assert_nil @object.instance_variable_get(:@foo)
-            refute @object.instance_variable_defined?(:@foo)
-          end
-        end
-
-        describe "getting an instance's class" do
-          specify "returns the class" do
-            assert_equal @class, @object.class
-          end
-        end
-
-        describe "#kind_of?" do
-          it "returns true for #{@class}" do
-            assert @object.kind_of?(@class)
-          end
-
-          it "returns false for non-#{@class}" do
-            other_class = @Class.new
-            refute @object.kind_of?(other_class)
-          end
-        end
-
-        describe "#inspect" do
-          it "inspects the object" do
-            assert_match(/#<#{@class}(:.*)?>/, @object.inspect)
-          end
-        end
-
-        describe "#to_s" do
-          it "returns Stringified version of the object" do
-            assert_match(/#<#{@class}(:.*)?>/, @object.to_s)
-          end
-        end
+        include ObjectBehaviourTests
       end
     end
   end


### PR DESCRIPTION
This essentially unnecessary PR provides closure on something we tried but failed to do during a recent pairing session: move the tests out of the metaprogramming loops so that we can reuse or reorganise them if we ever want to.

The extraction itself was simple enough — what we missed during pairing is that we need to put the `describe` inside a `Module#included` hook for some reason — but it also nerd sniped me into doing a bit of variable naming (and renaming) to make our intent clearer. I’d appreciate feedback on whether this has in fact improved clarity rather than making everything more confusing; the individual commit messages explain my reasoning, such as it is.

I haven’t actually added or changed any tests here, just moved them around. I think having the tests in their own modules does create the opportunity to reuse them (e.g. `before do @class = ns::Class; @object = singleton; end … include ObjectBehaviourTests`) or reorganise them (e.g. `describe ns::Class do … include ObjectBehaviourTests; include ModuleBehaviourTests; include ClassBehaviourTests … end`) if we wanted to, but that’s not necessarily something we need to do. I just wanted to scratch the itch if I’m honest.