### PR TITLE
Improve class relationships test

### DIFF
--- a/test/class_relationships_test.rb
+++ b/test/class_relationships_test.rb
@@ -1,74 +1,79 @@
 require "test_helper"
 
-[
-  [::Object, ::Module, ::Class],
-  [Toy::Object, Toy::Module, Toy::Class]
-].each do |_Object, _Module, _Class|
-  describe "relationships between Object, Module and Class" do
-    describe "#class" do
-      specify "Object’s class is Class" do
-        assert_equal _Class, _Object.class
-      end
-
-      specify "Module’s class is Class" do
-        assert_equal _Class, _Module.class
-      end
-
-      specify "Class’s class is Class" do
-        assert_equal _Class, _Class.class
-      end
+[::Object, ::Toy].each do |ns|
+  describe "in the #{ns} namespace" do
+    before do
+      @Class = ns::Class
+      @Module = ns::Module
+      @Object = ns::Object
     end
 
-    describe "#superclass" do
-      specify "Class’s superclass is Module" do
-        assert_equal _Module, _Class.superclass
-      end
-
-      specify "Module’s superclass is Object" do
-        assert_equal _Object, _Module.superclass
-      end
-    end
-
-    describe "#kind_of?" do
-      describe "Object" do
-        specify "Object is a kind of Object" do
-          assert_kind_of _Object, _Object
+    describe "relationships between Object, Module and Class" do
+      describe "#class" do
+        specify "Object’s class is Class" do
+          assert_equal @Class, @Object.class
         end
 
-        specify "Object is a kind of Module" do
-          assert_kind_of _Module, _Object
+        specify "Module’s class is Class" do
+          assert_equal @Class, @Class.class
         end
 
-        specify "Object is a kind of Class" do
-          assert_kind_of _Class, _Object
+        specify "Class’s class is Class" do
+          assert_equal @Class, @Class.class
         end
       end
 
-      describe "Module" do
-        specify "Module is a kind of Object" do
-          assert_kind_of _Object, _Module
+      describe "#superclass" do
+        specify "Class’s superclass is Module" do
+          assert_equal @Module, @Class.superclass
         end
 
-        specify "Module is a kind of Module" do
-          assert_kind_of _Module, _Module
-        end
-
-        specify "Module is a kind of Class" do
-          assert_kind_of _Class, _Module
+        specify "Module’s superclass is Object" do
+          assert_equal @Object, @Module.superclass
         end
       end
 
-      describe "Class" do
-        specify "Class is a kind of Object" do
-          assert_kind_of _Object, _Class
+      describe "#kind_of?" do
+        describe "Object" do
+          specify "Object is a kind of Object" do
+            assert_kind_of @Object, @Object
+          end
+
+          specify "Object is a kind of Module" do
+            assert_kind_of @Module, @Object
+          end
+
+          specify "Object is a kind of Class" do
+            assert_kind_of @Class, @Object
+          end
         end
 
-        specify "Class is a kind of Module" do
-          assert_kind_of _Module, _Class
+        describe "Module" do
+          specify "Module is a kind of Object" do
+            assert_kind_of @Object, @Module
+          end
+
+          specify "Module is a kind of Module" do
+            assert_kind_of @Module, @Module
+          end
+
+          specify "Module is a kind of Class" do
+            assert_kind_of @Class, @Module
+          end
         end
 
-        specify "Class is a kind of Class" do
-          assert_kind_of _Class, _Class
+        describe "Class" do
+          specify "Class is a kind of Object" do
+            assert_kind_of @Object, @Class
+          end
+
+          specify "Class is a kind of Module" do
+            assert_kind_of @Module, @Class
+          end
+
+          specify "Class is a kind of Class" do
+            assert_kind_of @Class, @Class
+          end
         end
       end
     end


### PR DESCRIPTION
Building on the work done in #30, I've made some changes to the class relationships test! Rather than iterating over two sets of objects, and deconstructing each set into the appropriate role the object should play (`_Object`, `_Module`, `_Class`), I decided to simplify the meta-programming loop to iterate over the namespace instead. Then, following suit with our other tests, we can assign the singletons outside of the test loop, because these will always be the same.

