### PR TITLE
Singletons as instance classes

### DIFF
--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -1,32 +1,14 @@
 module Toy
-  Class = BasicObject.new
+  Class = ClassInstance.new(superclass: Module)
 
   # Open up singleton class of Toy::Class
   class << Class
-    # Object instance methods, because the Class singleton is an object yo!
-    include Behaviours::InstanceVariables
-
-    # Module instance methods, because the Class singleton is a module yo!
-    include Behaviours::Constants
-    include Behaviours::Methods
-
-    # kind_of?
-    include Behaviours::ClassRelationships
-
-    def to_s
-      inspect
-    end
-
     def inspect
       "Toy::Class"
     end
 
     def class
       Class
-    end
-
-    def superclass
-      Module
     end
 
     def new(superclass = Object)

--- a/lib/toy/class.rb
+++ b/lib/toy/class.rb
@@ -30,7 +30,7 @@ module Toy
     end
 
     def new(superclass = Object)
-      ClassInstance.new(self, superclass)
+      ClassInstance.new(klass: self, superclass: superclass)
     end
   end
 end

--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -1,7 +1,7 @@
 module Toy
   class ClassInstance < ModuleInstance
     def initialize(klass: nil, superclass: nil)
-      super(klass)
+      super(klass: klass)
       @superclass = superclass
     end
 
@@ -11,7 +11,7 @@ module Toy
 
     # Class instance methods
     def new
-      ObjectInstance.new(self)
+      ObjectInstance.new(klass: self)
     end
   end
 end

--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -1,6 +1,6 @@
 module Toy
   class ClassInstance < ModuleInstance
-    def initialize(klass, superclass)
+    def initialize(klass: nil, superclass: nil)
       super(klass)
       @superclass = superclass
     end

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -1,32 +1,14 @@
 module Toy
-  Module = BasicObject.new
+  Module = ClassInstance.new(superclass: Object)
 
   # Open up singleton class of Toy::Module
   class << Module
-    # Object instance methods, because the Module singleton is an object yo!
-    include Behaviours::InstanceVariables
-
-    # Module instance methods, because the Module singleton is a module yo!
-    include Behaviours::Constants
-    include Behaviours::Methods
-
-    # kind_of?
-    include Behaviours::ClassRelationships
-
-    def to_s
-      inspect
-    end
-
     def inspect
       "Toy::Module"
     end
 
     def class
       Class
-    end
-
-    def superclass
-      Object
     end
 
     def new

--- a/lib/toy/module.rb
+++ b/lib/toy/module.rb
@@ -30,7 +30,7 @@ module Toy
     end
 
     def new
-      ModuleInstance.new(self)
+      ModuleInstance.new(klass: self)
     end
   end
 end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -30,7 +30,7 @@ module Toy
     end
 
     def new
-      ObjectInstance.new(self)
+      ObjectInstance.new(klass: self)
     end
   end
 end

--- a/lib/toy/object.rb
+++ b/lib/toy/object.rb
@@ -1,28 +1,10 @@
 module Toy
-  Object = BasicObject.new
+  Object = ClassInstance.new
 
   # Open up singleton class of Toy::Object
   class << Object
-    # Object instance methods, because the Object singleton is an object yo!
-    include Behaviours::InstanceVariables
-
-    # Module instance methods, because the Object singleton is a module yo!
-    include Behaviours::Constants
-    include Behaviours::Methods
-
-    # kind_of?
-    include Behaviours::ClassRelationships
-
-    def to_s
-      inspect
-    end
-
     def inspect
       "Toy::Object"
-    end
-
-    def superclass
-      nil
     end
 
     def class

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -9,7 +9,7 @@ module Toy
     # to_s and #inspect
     include Behaviours::Inspection
 
-    def initialize(klass)
+    def initialize(klass: nil)
       @klass = klass
     end
 


### PR DESCRIPTION
This PR accomplishes two things:
1) Modifies the `ClassInstance` and `ObjectInstance` constructors to take keyword args for improved clarity
2) Changes the `Toy::{Object|Module|Class}` singletons to be `ClassInstances` rather than instantiating them as `BasicObject`s directly. This allows to remove a bunch of the duplication in each of the respective singletons, since much of this behaviour is already defined in `ClassInstance` (since it is, after all,  _class instance behaviour_).

Of note: we cannot pass the `klass` and `superclass` arguments into the `ClassInstance` constructor when initializing our singletons. This code is reference at load time -- as such, we get into a circular dependency situation, where upon loading `Toy::Class`, we attempt to load `Toy::Module`, which references `Toy::Class`  which was in the process of being loaded in the first place. To solve this problem, we opted to not instantiate the singletons with kwargs, and to define getters on each of the singletons that return the appropriate value for `class` and `superclass.