### PR TITLE
Support `ObjectInstance#method` method

### DIFF
--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -45,6 +45,23 @@ module Toy
       @klass
     end
 
+    def method(selector)
+      superclass = self.class
+      while superclass
+        return Method.new(superclass) if superclass.instance_methods.include?(selector)
+        superclass = superclass.superclass
+      end
+      ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.class.inspect}'"
+    end
+
+    class Method < BasicObject
+      def initialize(owner)
+        @owner = owner
+      end
+
+      attr_reader :owner
+    end
+
     private
 
     def ivar_map

--- a/test/method_lookup_test.rb
+++ b/test/method_lookup_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class MethodLookupTest
+  [::Object, ::Toy].each do |ns|
+    describe "in the #{ns} namespace" do
+      before do
+        @Class = ns::Class
+        @class = @Class.new
+      end
+
+      describe "method lookup behaviour" do
+        specify "#method raises NameError when object doesn't define selector method" do
+          object = @class.new
+          error = assert_raises(NameError) do
+            object.method(:unknown_method)
+          end
+          assert_match(/undefined method `unknown_method'/, error.message)
+        end
+
+        describe "the object returned by #method" do
+          specify "knows the module or class that defined the method" do
+            body = proc { puts "Hello World!" }
+            @class.define_method(:my_method, body)
+
+            object = @class.new
+            assert_equal(@class, object.method(:my_method).owner)
+          end
+
+          specify "knows when a superclass defined the method" do
+            body = proc { puts "Hello World!" }
+            @class.define_method(:my_method, body)
+
+            subclass = @Class.new(@class)
+
+            object = subclass.new
+            assert_equal(@class, object.method(:my_method).owner)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This method returns an object (`Toy::ObjectInstance::Method`) that responds to `#owner`.
The method object is attached to the object instance, meaning that calling `#owner` on
it will return the class | module where that is method is defined _for that object instance_.

For now, we achieve this by walking up the superclass hierarchy and asking the class for its
instance methods, checking if one of them is the selector. If we find a match,
we init a `Method` object whose `owner` is that class. If we walk the whole superclass hierarchy
and don't find the method, we raise a `NameError` akin to how Ruby would.