### PR TITLE
Support Mixins

### DIFF
--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -40,7 +40,7 @@ module Toy
     end
 
     def include(mod)
-      included_modules.prepend(mod)
+      included_modules.prepend(mod) unless included_modules.include?(mod)
     end
 
     def included_modules

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -39,6 +39,14 @@ module Toy
       method_map.keys.map(&:to_sym)
     end
 
+    def include(mod)
+      included_modules << mod
+    end
+
+    def included_modules
+      @included_modules ||= []
+    end
+
     private
 
     def constant_map

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -40,7 +40,7 @@ module Toy
     end
 
     def include(mod)
-      included_modules << mod
+      included_modules.prepend(mod)
     end
 
     def included_modules

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -47,6 +47,11 @@ module Toy
 
     def method(selector)
       superclass = self.class
+      # Check mixed-in Modules to see if they define the selector
+      superclass.included_modules.each do |mixin|
+        return Method.new(mixin) if mixin.instance_methods.include?(selector)
+      end
+      # Check up the superclass hierarchy to see if any of them define the selector
       while superclass
         return Method.new(superclass) if superclass.instance_methods.include?(selector)
         superclass = superclass.superclass

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -47,13 +47,17 @@ module Toy
 
     def method(selector)
       superclass = self.class
-      # Check mixed-in Modules to see if they define the selector
-      superclass.included_modules.each do |mixin|
-        return Method.new(mixin) if mixin.instance_methods.include?(selector)
-      end
-      # Check up the superclass hierarchy to see if any of them define the selector
+
+      # Check up the superclass hierarchy to see if any of them define the selector.
+      # Check the superclasses to see if any of their mixins define the selector.
       while superclass
         return Method.new(superclass) if superclass.instance_methods.include?(selector)
+
+        # Check mixed-in Modules to see if they define the selector
+        superclass.included_modules.each do |mixin|
+          return Method.new(mixin) if mixin.instance_methods.include?(selector)
+        end
+
         superclass = superclass.superclass
       end
       ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.class.inspect}'"

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -49,19 +49,13 @@ module Toy
       superclass = self.class
 
       # Check up the superclass hierarchy to see if any of them define the selector.
-      # Check the superclasses to see if any of their mixins define the selector.
       while superclass
-        return Method.new(superclass) if superclass.instance_methods.include?(selector)
+        # Check mixed-in modules to see if they define the selector
+        method = mixin_ancestry_search(superclass, selector)
+        return method if method
 
-        # Check mixed-in Modules to see if they define the selector
-        superclass.included_modules.each do |mixin|
-          return Method.new(mixin) if mixin.instance_methods.include?(selector)
-
-          mixin.included_modules.each do |moar_mixins|
-            return Method.new(moar_mixins) if moar_mixins.instance_methods.include?(selector)
-          end
-        end
-
+        # The current class did not define the method, nor did any of its mixins.
+        # Move up to the superclass to see if it, or any of its modules, contain the method.
         superclass = superclass.superclass
       end
       ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.class.inspect}'"
@@ -79,6 +73,18 @@ module Toy
 
     def ivar_map
       @ivar_map ||= {}
+    end
+
+    def mixin_ancestry_search(mixin, selector)
+      return Method.new(mixin) if mixin.instance_methods.include?(selector)
+
+      mixin.included_modules.each do |nested_mixin|
+        method = mixin_ancestry_search(nested_mixin, selector)
+        return method if method
+      end
+
+      # No method match was found at this level in the tree, return nil
+      nil
     end
   end
 end

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -56,6 +56,10 @@ module Toy
         # Check mixed-in Modules to see if they define the selector
         superclass.included_modules.each do |mixin|
           return Method.new(mixin) if mixin.instance_methods.include?(selector)
+
+          mixin.included_modules.each do |moar_mixins|
+            return Method.new(moar_mixins) if moar_mixins.instance_methods.include?(selector)
+          end
         end
 
         superclass = superclass.superclass

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -3,6 +3,19 @@ require "test_helper"
 class MixinTest
   [::Object, ::Toy].each do |ns|
     describe "in the #{ns} namespace" do
+      describe "#included_modules" do
+        it "returns list of modules that have been mixed into module" do
+          m = ns::Module.new
+          c = ns::Class.new
+          c.include(m)
+
+          assert_includes(c.included_modules, m)
+        end
+      end
+
+      describe "including a module in a module" do
+      end
+
       describe "including a module in a class" do
         specify "define module with method, include module in new class, instantiate class" do
           m = ns::Module.new

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -14,6 +14,7 @@ class MixinTest
       end
 
       describe "including a module in a module" do
+        # TO DO - ensure we test this behaviour against Module
       end
 
       describe "including a module in a class" do
@@ -38,6 +39,33 @@ class MixinTest
 
           m.define_method(:my_method, proc { puts "Hello World!" })
           assert_equal(m, o.method(:my_method).owner)
+        end
+
+        specify "mixes in behaviour to a subclass" do
+          m = ns::Module.new
+          m.define_method(:my_method, proc { puts "Hello World!" })
+
+          c = ns::Class.new
+          c.include(m)
+
+          subclass = ns::Class.new(c)
+
+          o = subclass.new
+
+          assert_equal(m, o.method(:my_method).owner)
+        end
+
+        specify "when a class overrides a mixin's method, knows the class defined it" do
+          m = ns::Module.new
+          m.define_method(:my_method, proc { puts "Hello World!" })
+
+          c = ns::Class.new
+          c.include(m)
+          c.define_method(:my_method, proc { puts "I override my mixin's method!" })
+
+          o = c.new
+
+          assert_equal(c, o.method(:my_method).owner)
         end
       end
     end

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -67,6 +67,23 @@ class MixinTest
 
           assert_equal(c, o.method(:my_method).owner)
         end
+
+        describe "when a class includes multiple modules that define a method" do
+          it "uses the behaviour defined in the most recently included module" do
+            module_a = ns::Module.new
+            module_a.define_method(:my_method, proc { "Called from module A" })
+            module_b = ns::Module.new
+            module_b.define_method(:my_method, proc { "Called from module B" })
+
+            c = ns::Class.new
+            c.include(module_a)
+            c.include(module_b)
+
+            o = c.new
+
+            assert_equal(module_b, o.method(:my_method).owner)
+          end
+        end
       end
     end
   end

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -113,6 +113,23 @@ class MixinTest
             assert_equal(module_b, o.method(:my_method).owner)
           end
         end
+
+        describe "including a module that includes other modules" do
+          it "defines behaviour from transitively included modules in class" do
+            module_a = ns::Module.new
+            module_b = ns::Module.new
+            module_b.define_method(:my_method, proc { "Called from module B" })
+
+            module_a.include(module_b)
+
+            c = ns::Class.new
+            c.include(module_a)
+
+            o = c.new
+
+            assert_equal(module_b, o.method(:my_method).owner)
+          end
+        end
       end
     end
   end

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -84,6 +84,35 @@ class MixinTest
             assert_equal(module_b, o.method(:my_method).owner)
           end
         end
+
+        describe "including the same module twice" do
+          it "only adds module to list of included_modules once" do
+            m = ns::Module.new
+            m.define_method(:my_method, proc { "Hello world!" })
+
+            c = ns::Class.new
+            c.include(m)
+            c.include(m)
+
+            assert_equal(1, c.included_modules.select { |mod| mod == m }.size)
+          end
+
+          it "doesn't affect method lookup" do
+            module_a = ns::Module.new
+            module_a.define_method(:my_method, proc { "Called from module A" })
+            module_b = ns::Module.new
+            module_b.define_method(:my_method, proc { "Called from module B" })
+
+            c = ns::Class.new
+            c.include(module_a)
+            c.include(module_b)
+            c.include(module_a)
+
+            o = c.new
+
+            assert_equal(module_b, o.method(:my_method).owner)
+          end
+        end
       end
     end
   end

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class MixinTest
+  [::Object, ::Toy].each do |ns|
+    describe "in the #{ns} namespace" do
+      describe "including a module in a class" do
+        specify "define module with method, include module in new class, instantiate class" do
+          m = ns::Module.new
+          m.define_method(:my_method, proc { puts "Hello World!" })
+
+          c = ns::Class.new
+          c.include(m)
+
+          o = c.new
+
+          assert_equal(m, o.method(:my_method).owner)
+        end
+
+        specify "instantiate new class, include module, define method on module" do
+          c = ns::Class.new
+          o = c.new
+
+          m = ns::Module.new
+          c.include(m)
+
+          m.define_method(:my_method, proc { puts "Hello World!" })
+          assert_equal(m, o.method(:my_method).owner)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces mixin behaviour to our toy object model. Modules can be mixed into either classes or modules to provide instance behaviour. We account for nested mixing-in of modules and things like including a module twice.

Right now, method lookup operates by finding the current class, checking its mixins (and ancestor mixins, searched recursively) for the provided selector, and then proceeding to the superclass if no method is found. Method lookup still occurs in the `ObjectInstance` class, although a future PR will see this logic moved to the `ModuleInstance` class, since it is the class / module who needs to answer the question "do I contain a definition for a given method selector?" 

It's also worth noting that MRI (the real Ruby implementation) performs method lookup on a single, flat list of objects -- both modules and classes are stored in a single inheritance hierarchy. We will also look at refactoring our toy code to match this implementation in a future PR -- but for now, we maintain two separate inheritance chains on which to perform method lookup (the superclass ancestor chain, and the mixins tree).