### PR TITLE
Refactor Method Lookup

### DIFF
--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -45,9 +45,11 @@ module Toy
       included_modules.each do |nested_mixin|
         method = nested_mixin.instance_method(selector)
         return method if method
+      rescue ::NameError
+        nil
       end
 
-      if superclass
+      if self.class == Class && superclass
         superclass.instance_method(selector)
       else
         ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.inspect}'"

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -39,6 +39,22 @@ module Toy
       method_map.keys.map(&:to_sym)
     end
 
+    def instance_method(selector)
+      selector = selector.to_sym
+
+      current_class = self
+      while current_class
+        # Check mixed-in modules to see if they define the selector
+        method = mixin_ancestry_search(current_class, selector)
+        return method if method
+
+        # The current class did not define the method, nor did any of its mixins.
+        # Move up to the superclass to see if it, or any of its modules, contain the method.
+        current_class = current_class.superclass
+      end
+      ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.inspect}'"
+    end
+
     def include(mod)
       included_modules.prepend(mod) unless included_modules.include?(mod)
     end
@@ -55,6 +71,18 @@ module Toy
 
     def method_map
       @method_map ||= {}
+    end
+
+    def mixin_ancestry_search(mixin, selector)
+      return Method.new(mixin) if mixin.instance_methods.include?(selector)
+
+      mixin.included_modules.each do |nested_mixin|
+        method = mixin_ancestry_search(nested_mixin, selector)
+        return method if method
+      end
+
+      # No method match was found at this level in the tree, return nil
+      nil
     end
   end
 end

--- a/lib/toy/object_instance.rb
+++ b/lib/toy/object_instance.rb
@@ -46,19 +46,7 @@ module Toy
     end
 
     def method(selector)
-      superclass = self.class
-
-      # Check up the superclass hierarchy to see if any of them define the selector.
-      while superclass
-        # Check mixed-in modules to see if they define the selector
-        method = mixin_ancestry_search(superclass, selector)
-        return method if method
-
-        # The current class did not define the method, nor did any of its mixins.
-        # Move up to the superclass to see if it, or any of its modules, contain the method.
-        superclass = superclass.superclass
-      end
-      ::Kernel.raise ::NameError, "undefined method `#{selector}' for class `#{self.class.inspect}'"
+      self.class.instance_method(selector)
     end
 
     class Method < BasicObject
@@ -73,18 +61,6 @@ module Toy
 
     def ivar_map
       @ivar_map ||= {}
-    end
-
-    def mixin_ancestry_search(mixin, selector)
-      return Method.new(mixin) if mixin.instance_methods.include?(selector)
-
-      mixin.included_modules.each do |nested_mixin|
-        method = mixin_ancestry_search(nested_mixin, selector)
-        return method if method
-      end
-
-      # No method match was found at this level in the tree, return nil
-      nil
     end
   end
 end


### PR DESCRIPTION
Following up on https://github.com/adrianna-chang-shopify/ruby-object-model/pull/36, this PR is an intermediate refactor of our method lookup code. We are not yet at the point of making implementation match real Ruby -- this is still yet to come!

11a52818b431971a378e4956cdf78fbdef359898 moves instance method lookup from `ObjectInstance` to `ModuleInstance`; as discussed in the above PR, having method lookup implemented on the `Object` class was a "feature envy" smell. It's more appropriate for a Module to be able to answer questions about whether it contains a definition for a given method.

eb7a93fbf60dfa707c377880148c3b12096b0b52 cleans up the `#instance_method` method further to get rid of the `#mixin_ancestry_search` helper method, opting instead to recursively use `#instance_method` to search up the mixin ancestry tree. Unfortunately, this introduced a bug, evidenced by the changes added in 0b12bd2b368b5cc8e08b311d76de6a4a3b9b2409. `Module`s don't respond to `superclass`, so we need to check whether `self` is currently a `Class` before asking to move up to the superclass. If `self` is a Module, we raise. We have another problem here: we don't know whether we're at the root of the mixin tree when we raise. In other words, if we're looking through a module's modules and we don't find our method, we don't want to raise an error -- we want to return from the current level of `#instance_method` and continue our DFS. Consequently, we "cheat" a bit and rescue the `NameError` we raise in the block provided for `included_modules.each`.