### PR TITLE
Implement `#ancestors` for Modules

### DIFF
--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -9,6 +9,12 @@ module Toy
       @superclass
     end
 
+    def ancestors
+      class_ancestors = super.uniq(&:__id__)
+      class_ancestors += superclass.ancestors if superclass
+      class_ancestors
+    end
+
     # Class instance methods
     def new
       ObjectInstance.new(klass: self)

--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -9,6 +9,12 @@ module Toy
       @superclass
     end
 
+    # This is still problematic if there's duplication between this class's ancestors
+    # and its superclass (and its ancestors)
+    # Does this fix it?
+    # class_ancestors = super
+    # class_ancestors += superclass.ancestors if superclass
+    # class_ancestors.uniq { |ancestor| ancestor.__id__ }
     def ancestors
       class_ancestors = super.uniq(&:__id__)
       class_ancestors += superclass.ancestors if superclass

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -39,6 +39,13 @@ module Toy
       method_map.keys.map(&:to_sym)
     end
 
+    # Tom's seed: Maybe give modules the concept of a "superclass" -ie. parent
+    # Instead of including modules => pushing into an array, maybe build linked list of parents
+
+    def ancestors
+      [self, *included_modules.flat_map(&:ancestors)]
+    end
+
     def instance_method(selector)
       return Method.new(self) if instance_methods.include?(selector)
 

--- a/test/method_lookup_test.rb
+++ b/test/method_lookup_test.rb
@@ -8,6 +8,48 @@ class MethodLookupTest
         @class = @Class.new
       end
 
+      # class Z; end
+
+      # class Y < Z
+      #   include A
+      # end
+
+      # module A
+      #   include B
+      # end
+
+      # module B
+      #   include C
+      #   include D
+      # end
+
+      # module C
+      #   include D
+      # end
+
+      # module D; end
+
+      describe "#ancestors" do
+        it "returns list of ancestors" do
+          module_a = ns::Module.new
+          module_b = ns::Module.new
+          module_c = ns::Module.new
+          module_d = ns::Module.new
+
+          module_a.include(module_b)
+          module_b.include(module_c)
+
+          module_b.include(module_d)
+          module_c.include(module_d)
+
+          class_z = @Class.new
+          class_z.include(module_a)
+
+          expected_ancestors = [class_z, module_a, module_b, module_d, module_c, ns::Object]
+          assert_equal expected_ancestors, class_z.ancestors.take(expected_ancestors.length)
+        end
+      end
+
       describe "method lookup behaviour" do
         specify "#method raises NameError when object doesn't define selector method" do
           object = @class.new


### PR DESCRIPTION
Implements `#ancestors` method on `ModuleInstance` and `ClassInstance`. We're hoping that this facilitates changes to our method lookup strategy so that we match MRI's behaviour 🤞 

Behaviour for modules:
- Returns the current module + its mixins 
- If a mixin is included in multiple modules in the ancestry chain, the mixin shows up multiple times

Behaviour for classes:
- Returns the current class + its mixins + the class's superclass + its mixins, and so on
- Mixins are deduped!
- We need to fix this properly next time, because we're not deduping in all circumstances (see added note 😂 )

