### PR TITLE
Reimplement object inheritance and method lookups

### DIFF
--- a/lib/toy/class_instance.rb
+++ b/lib/toy/class_instance.rb
@@ -3,22 +3,11 @@ module Toy
     def initialize(klass: nil, superclass: nil)
       super(klass: klass)
       @superclass = superclass
+      @superclass_ptr = superclass
     end
 
     def superclass
       @superclass
-    end
-
-    # This is still problematic if there's duplication between this class's ancestors
-    # and its superclass (and its ancestors)
-    # Does this fix it?
-    # class_ancestors = super
-    # class_ancestors += superclass.ancestors if superclass
-    # class_ancestors.uniq { |ancestor| ancestor.__id__ }
-    def ancestors
-      class_ancestors = super.uniq(&:__id__)
-      class_ancestors += superclass.ancestors if superclass
-      class_ancestors
     end
 
     # Class instance methods

--- a/lib/toy/module_instance.rb
+++ b/lib/toy/module_instance.rb
@@ -57,8 +57,6 @@ module Toy
 
     # Returns the list of modules included or prepended in mod or one of mod’s ancestors.
     def include(mod)
-      ::Kernel.puts("Including #{mod} in #{self}")
-      ::Kernel.puts("Do ancestors already include #{mod}? #{ancestors.include?(mod)}")
       # Avoid including module that already exists in the hierarchy
       return if ancestors.include?(mod)
 
@@ -69,13 +67,8 @@ module Toy
       return unless previous_superclass_ptr
 
       # Superclass pointer at end of hierarchy for module being included needs to point to previous superclass pointer
-      ptr = mod
-      while ptr && ptr.superclass_ptr
-        ptr = ptr.superclass_ptr
-      end
-
-      ::Kernel.puts("Setting #{ptr.superclass_ptr} to #{previous_superclass_ptr}")
-      ptr.superclass_ptr = previous_superclass_ptr
+      module_at_end_of_hierarchy = mod.ancestors.last
+      module_at_end_of_hierarchy.superclass_ptr = previous_superclass_ptr
     end
 
     # Traverse inclusion tree, flattening (remove duplicates / cycles)

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -14,7 +14,34 @@ class MixinTest
       end
 
       describe "including a module in a module" do
-        # TO DO - ensure we test this behaviour against Module
+        it "adds the mixin to the module's included_modules" do
+          module_a = ns::Module.new
+          module_a.define_method(:my_method, proc { puts "Hello World!" })
+
+          module_b = ns::Module.new
+          module_b.include(module_a)
+
+          assert_includes(module_b.included_modules, module_a)
+        end
+
+        it "adds module to list of included modules even if another mixin already includes that module" do
+          module_a = ns::Module.new
+          def module_a.name; "module_a"; end
+
+          module_b = ns::Module.new
+          def module_b.name; "module_b"; end
+
+          module_c = ns::Module.new
+          def module_c.name; "module_c"; end
+
+          module_b.include(module_c)
+
+          module_a.include(module_b)
+          module_a.include(module_c)
+
+          assert_equal([module_b, module_c], module_a.included_modules)
+          assert_equal([module_a, module_b, module_c], module_a.ancestors)
+        end
       end
 
       describe "including a module in a class" do

--- a/test/mixin_test.rb
+++ b/test/mixin_test.rb
@@ -239,12 +239,64 @@ class MixinTest
 
             o = c.new
 
-            # owner is module_c since it's "root module" (module A)
+            # owner is module_c since its "root module" (module A)
             # was included last on the class. This is the case even though
             # module C is at a "deeper level" in the tree compared to module E.
             # DFS
             assert_equal(module_c, o.method(:my_method).owner)
           end
+        end
+
+        describe "including a module in a class and its superclass" do
+          it "resolves method to module if the class includes the mixin first" do
+            module_a = ns::Module.new
+            module_a.define_method(:my_method, proc { "Called from module A" })
+
+            class_y = ns::Class.new
+            class_y.define_method(:my_method, proc { "Called from class Y" })
+
+            class_z = ns::Class.new(class_y)
+
+            # Because class_z includes the module first, lookup will find
+            # #my_method on the module
+            class_z.include(module_a)
+            class_y.include(module_a)
+
+            o = class_z.new
+            assert_equal(module_a, o.method(:my_method).owner)
+          end
+
+          it "ignores the mixin included on the class if the superclass includes mixin first" do
+            module_a = ns::Module.new
+            module_a.define_method(:my_method, proc { "Called from module A" })
+            def module_a.name; "module_a"; end
+
+            class_y = ns::Class.new
+            class_y.define_method(:my_method, proc { "Called from class Y" })
+            def class_y.name; "class_y"; end
+
+            class_z = ns::Class.new(class_y)
+            def class_z.name; "class_z"; end
+
+            # Because class_y includes the mixin first, when class_z includes
+            # the mixin it's effectively a no-op because that module already
+            # appears in the ancestry chain, and consequently the method
+            # lookup finds #my_method on class_y
+            class_y.include(module_a)
+            class_z.include(module_a)
+
+            o = class_z.new
+            expected_ancestors = [class_z, class_y, module_a, ns::Object]
+            assert_equal(expected_ancestors, class_z.ancestors.take(expected_ancestors.length))
+            assert_equal(class_y, o.method(:my_method).owner)
+          end
+
+          # Note: we could have another test case where the order is switched
+          # and then the module would show up twice!
+          # class_z.include(module_a)
+          # class_y.include(module_a)
+
+          # class_z.ancestors => [class_z, module_a, class_y, module_a]
         end
       end
     end


### PR DESCRIPTION
Instead of representing inheritance as an ordered array, model it more closely to CRuby's internal representation, where both modules and classes are `RClass` objects, with superclass pointers. Inheritance is modelled as a singly linked list, where an `RClass` stores a pointer to its superclass (be it a module or a true superclass).

This gets us around all the weird issues with deduplicating ancestors.

Note that I've kind of hacked `#traverse_ancestors` to avoid getting into cycles. This test demonstrates the issue:
```ruby
      describe "#ancestors" do
        it "returns list of ancestors" do
          module_a = ns::Module.new
          module_b = ns::Module.new
          module_c = ns::Module.new
          module_d = ns::Module.new

          module_a.include(module_b)
          module_b.include(module_c)

          module_b.include(module_d)
          module_c.include(module_d)

          class_z = @Class.new
          class_z.include(module_a)

          expected_ancestors = [class_z, module_a, module_b, module_d, module_c, ns::Object]
          assert_equal expected_ancestors, class_z.ancestors.take(expected_ancestors.length)
        end
      end
```

The ancestor chain is represented as Z => A => B => D => C => D, where D => C => D is a cycle. If we attempt to traverse this, we'll end up cycling through infinitely. In order to get around this, I've opted to break any cycles at the moment of traversal:
```ruby
    def traverse_ancestors
      ptr = superclass_ptr
      ancestors = ptr ? [ptr] : []

      while ptr && ptr.superclass_ptr do
        ptr = ptr.superclass_ptr
        break if ancestors.include?(ptr) # Avoid cycles
        ancestors << ptr
      end
      ancestors
    end
```

I don't think this is technically correct, since there _are_ valid Ruby cases for a module showing up twice in the inheritance hierarchy, e.g.:
```ruby
module_a = ns::Module.new

class_y = ns::Class.new
class_z = ns::Class.new(class_y)

class_z.include(module_a)
class_y.include(module_a)

class_z.ancestors => [class_z, module_a, class_y, module_a] # This is the result in real Ruby
```

I suspect we may need to eventually model things slightly differently so that the modules in the hierarchy aren't really representing the same object, so that we never end up with cycles, but I'm not sure how to make that work 🤔 Will come back to this, since it's a more complex use case.